### PR TITLE
Tighten .gitignore template generated by simctl init

### DIFF
--- a/src/simctl/templates/scaffold/gitignore.txt
+++ b/src/simctl/templates/scaffold/gitignore.txt
@@ -11,17 +11,16 @@ refs/
 .simctl/knowledge/
 .simctl/environment.toml
 
-# heavy run outputs
-runs/**/work/outputs/
-runs/**/work/restart/
-runs/**/work/tmp/
+# Run work directory (simulator outputs, restart, logs, status snapshots)
+# Everything under work/ is regenerable from input/, so we exclude it whole
+# rather than trying to enumerate per-simulator output filenames.
+runs/**/work/
+runs/**/status/
 
-# logs
-runs/**/work/*.out
-runs/**/work/*.err
-runs/**/work/*.log
+# Preprocessor-generated input files (created by EMSES preinp from plasma.toml)
+runs/**/input/plasma.inp
 
-# analysis cache
+# analysis cache / scratch (curated outputs in analysis/ remain tracked)
 runs/**/analysis/cache/
 runs/**/analysis/scratch/
 runs/**/analysis/.ipynb_checkpoints/

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -90,9 +90,11 @@ class TestInit:
         """.gitignore contains run output exclusion patterns."""
         runner.invoke(app, ["init", "-y", "--path", str(tmp_path)])
         content = (tmp_path / ".gitignore").read_text(encoding="utf-8")
-        assert "runs/**/work/outputs/" in content
-        assert "runs/**/work/restart/" in content
-        assert "runs/**/work/tmp/" in content
+        # The whole work/ tree is regenerable from input/, so it is excluded
+        # wholesale rather than enumerating per-simulator output filenames.
+        assert "runs/**/work/" in content
+        assert "runs/**/status/" in content
+        assert "runs/**/input/plasma.inp" in content
         assert "runs/**/analysis/scratch/" in content
 
     def test_init_skips_existing_files(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The previous \`.gitignore\` template scaffolded by \`simctl init\` only excluded \`runs/**/work/{outputs,restart,tmp}/\` and \`*.{out,err,log}\`. In practice EMSES (and similar PIC simulators) write their HDF5 outputs and diagnostic ASCII files directly under \`runs/**/work/latest/\` without any of the above subdirectories, so the heavy outputs were accidentally trackable and easy to \`git add\` by mistake.

This PR replaces the per-subdirectory patterns with a single \`runs/**/work/\` exclusion (everything under \`work/\` is regenerable from \`input/\`) and adds two more entries:

- \`runs/**/status/\` — sync state snapshots written by \`simctl runs sync\`
- \`runs/**/input/plasma.inp\` — preinp output produced from \`plasma.toml\`

## Why

Running a real campaign in a project that ran into this gap: EMSES dumps ~1.4 GB / step worth of \`work/latest/*.h5\` per run. With the previous template these files were untracked-but-not-ignored, so a careless \`git add runs/series_X/\` would stage the whole tree. Excluding \`work/\` wholesale makes the default safe.

## Test plan

- [x] \`tests/test_cli/test_init.py::test_init_gitignore_content\` updated to assert the new patterns
- [x] \`uv run pytest tests/test_cli/test_init.py\` passes (39/39)
- [x] \`uv run ruff check tests/test_cli/test_init.py\` passes