### PR TITLE
Add `simctl runs cancel` and `simctl runs delete`

### DIFF
--- a/src/simctl/cli/main.py
+++ b/src/simctl/cli/main.py
@@ -16,7 +16,7 @@ from simctl.cli.jobs import jobs
 from simctl.cli.knowledge import knowledge_app
 from simctl.cli.list import list_runs
 from simctl.cli.log import log
-from simctl.cli.manage import archive, purge_work
+from simctl.cli.manage import archive, cancel, delete, purge_work
 from simctl.cli.new import new
 from simctl.cli.setup import setup
 from simctl.cli.status import status, sync
@@ -47,6 +47,8 @@ runs_app.command("clone")(clone)
 runs_app.command("extend")(extend)
 runs_app.command("archive")(archive)
 runs_app.command("purge-work")(purge_work)
+runs_app.command("cancel")(cancel)
+runs_app.command("delete")(delete)
 
 analyze_app = typer.Typer(
     name="analyze",

--- a/src/simctl/cli/manage.py
+++ b/src/simctl/cli/manage.py
@@ -1,4 +1,4 @@
-"""CLI commands for run lifecycle management: archive and purge."""
+"""CLI commands for run lifecycle management: archive, purge, cancel, delete."""
 
 from __future__ import annotations
 
@@ -9,6 +9,8 @@ import typer
 from simctl.cli.run_lookup import resolve_run_or_cwd
 from simctl.core.actions import ActionStatus
 from simctl.core.actions import archive_run as archive_run_action
+from simctl.core.actions import cancel_run as cancel_run_action
+from simctl.core.actions import delete_run as delete_run_action
 from simctl.core.actions import purge_work as purge_work_action
 from simctl.core.exceptions import SimctlError
 from simctl.core.manifest import read_manifest
@@ -122,4 +124,108 @@ def purge_work(
 
     typer.echo(f"Purged work files for run {run_id}.")
     typer.echo(f"  Freed: {_format_size(total_freed)}")
+    typer.echo(f"  Path: {run_dir}")
+
+
+def cancel(
+    run: str = typer.Argument(None, help="Run directory or run_id (defaults to cwd)."),
+    yes: bool = typer.Option(False, "--yes", help="Skip confirmation prompt."),
+) -> None:
+    """Cancel an active Slurm job (scancel) and sync the run state.
+
+    Combines ``scancel <job_id>`` and ``simctl runs sync`` so the manifest is
+    updated automatically.  Use this instead of bare ``scancel`` so the run
+    state ends up consistent.
+    """
+    run_dir = resolve_run_or_cwd(run, search_dir=Path.cwd())
+
+    try:
+        manifest = read_manifest(run_dir)
+    except SimctlError as e:
+        typer.echo(f"Error reading manifest: {e}", err=True)
+        raise typer.Exit(code=1) from None
+
+    current_status = manifest.run.get("status", "")
+    job_id = manifest.job.get("job_id", "")
+    run_id = manifest.run.get("id", "???")
+
+    if current_status not in {RunState.SUBMITTED.value, RunState.RUNNING.value}:
+        typer.echo(
+            "Error: can only cancel submitted/running runs, "
+            f"but run is '{current_status}'.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if not job_id:
+        typer.echo("Error: no job_id recorded in manifest.", err=True)
+        raise typer.Exit(code=1)
+
+    if not yes and not typer.confirm(
+        f"Cancel run {run_id} (Slurm job {job_id})?",
+        default=False,
+    ):
+        typer.echo("Cancelled.")
+        raise typer.Exit()
+
+    result = cancel_run_action(run_dir)
+    if result.status is not ActionStatus.SUCCESS:
+        typer.echo(f"Error: {result.message}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(result.message)
+    if result.state_after and result.state_before != result.state_after:
+        typer.echo(f"  State: {result.state_before} -> {result.state_after}")
+
+
+def delete(
+    run: str = typer.Argument(None, help="Run directory or run_id (defaults to cwd)."),
+    yes: bool = typer.Option(False, "--yes", help="Skip confirmation prompt."),
+) -> None:
+    """Hard-delete a run directory.
+
+    Only allowed for terminal non-completed states (created, cancelled,
+    failed) so existing results (completed/archived) are never lost.
+    Removes the entire run directory irreversibly.
+    """
+    run_dir = resolve_run_or_cwd(run, search_dir=Path.cwd())
+
+    try:
+        manifest = read_manifest(run_dir)
+    except SimctlError as e:
+        typer.echo(f"Error reading manifest: {e}", err=True)
+        raise typer.Exit(code=1) from None
+
+    current_status = manifest.run.get("status", "")
+    deletable = {
+        RunState.CREATED.value,
+        RunState.CANCELLED.value,
+        RunState.FAILED.value,
+    }
+    if current_status not in deletable:
+        typer.echo(
+            "Error: can only delete created/cancelled/failed runs, "
+            f"but run is '{current_status}'. "
+            "Use `simctl runs archive` (then purge-work) for completed runs.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    run_id = manifest.run.get("id", "???")
+    dir_size = _get_dir_size(run_dir)
+
+    if not yes and not typer.confirm(
+        f"Delete run {run_id} ({_format_size(dir_size)})? "
+        "This removes the directory irreversibly.",
+        default=False,
+    ):
+        typer.echo("Cancelled.")
+        raise typer.Exit()
+
+    result = delete_run_action(run_dir)
+    if result.status is not ActionStatus.SUCCESS:
+        typer.echo(f"Error: {result.message}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Deleted run {run_id}.")
+    typer.echo(f"  Freed: {_format_size(dir_size)}")
     typer.echo(f"  Path: {run_dir}")

--- a/src/simctl/core/actions.py
+++ b/src/simctl/core/actions.py
@@ -247,6 +247,28 @@ ACTION_SPECS: dict[str, ActionSpec] = {
         requires_confirmation=True,
         confirmation_reason="Purging deletes generated work files and is intentionally gated.",
     ),
+    "cancel_run": ActionSpec(
+        name="cancel_run",
+        description="Cancel an active Slurm job (scancel) and sync the run state.",
+        required_params=("run_dir",),
+        preconditions=("run state in {submitted, running}", "job_id recorded"),
+        state_change="submitted/running -> cancelled",
+        risk_level="medium",
+        cost_class="low",
+    ),
+    "delete_run": ActionSpec(
+        name="delete_run",
+        description="Hard-delete a run directory.  Only allowed for terminal "
+        "non-completed states (created, cancelled, failed) so existing "
+        "results are never lost.",
+        required_params=("run_dir",),
+        preconditions=("run state in {created, cancelled, failed}",),
+        destructive=True,
+        risk_level="high",
+        cost_class="low",
+        requires_confirmation=True,
+        confirmation_reason="Deletion removes the run directory irreversibly.",
+    ),
     "save_insight": ActionSpec(
         name="save_insight",
         description="Record a markdown knowledge insight.",
@@ -865,6 +887,105 @@ def purge_work(run_dir: Path) -> ActionResult:
         },
         state_before=state_str,
         state_after=RunState.PURGED.value,
+    )
+
+
+def cancel_run(run_dir: Path) -> ActionResult:
+    """Cancel an active Slurm job (scancel) and sync the run state.
+
+    Wraps ``scancel <job_id>`` followed by ``sync_run`` so the manifest is
+    updated atomically once Slurm reports the cancellation.  Use this instead
+    of bare ``scancel`` so the run state ends up consistent.
+    """
+    from simctl.core.manifest import read_manifest
+    from simctl.slurm.submit import (
+        SlurmCancelError,
+        SlurmNotFoundError,
+        scancel_job,
+    )
+
+    manifest = read_manifest(run_dir)
+    run_id = manifest.run.get("id", run_dir.name)
+    job_id = manifest.job.get("job_id", "")
+    if not job_id:
+        return _precondition_fail("cancel_run", "No job_id recorded in manifest")
+
+    state_str, err = _require_state(run_dir, RunState.SUBMITTED, RunState.RUNNING)
+    if err:
+        return _precondition_fail("cancel_run", err)
+
+    try:
+        scancel_job(job_id)
+    except SlurmNotFoundError as e:
+        return _error("cancel_run", str(e))
+    except SlurmCancelError as e:
+        return _error("cancel_run", str(e))
+
+    # Slurm typically takes a moment to mark the job as cancelled.  Run
+    # sync_run so the manifest reflects whatever Slurm reports right now;
+    # the caller can re-sync later if needed.
+    sync_result = sync_run(run_dir)
+
+    if sync_result.status is not ActionStatus.SUCCESS:
+        return ActionResult(
+            action="cancel_run",
+            status=ActionStatus.SUCCESS,
+            message=(
+                f"scancel sent for job {job_id}; sync did not complete "
+                f"({sync_result.message}).  Re-run `simctl runs sync` shortly."
+            ),
+            data={"run_id": run_id, "job_id": job_id},
+            state_before=state_str,
+            state_after=state_str,
+        )
+
+    return ActionResult(
+        action="cancel_run",
+        status=ActionStatus.SUCCESS,
+        message=f"Cancelled job {job_id}; {sync_result.message}",
+        data={
+            "run_id": run_id,
+            "job_id": job_id,
+            "slurm_state": sync_result.data.get("slurm_state", ""),
+        },
+        state_before=state_str,
+        state_after=sync_result.state_after or state_str,
+    )
+
+
+def delete_run(run_dir: Path) -> ActionResult:
+    """Hard-delete a run directory.
+
+    Only runs in a terminal non-completed state (``created``, ``cancelled``,
+    or ``failed``) may be deleted.  Completed and archived runs hold valuable
+    results and must go through the archive/purge flow instead.
+    """
+    state_str, err = _require_state(
+        run_dir,
+        RunState.CREATED,
+        RunState.CANCELLED,
+        RunState.FAILED,
+    )
+    if err:
+        return _precondition_fail("delete_run", err)
+
+    from simctl.core.manifest import read_manifest
+
+    run_id = read_manifest(run_dir).run.get("id", run_dir.name)
+    bytes_removed = _dir_size(run_dir)
+
+    try:
+        shutil.rmtree(run_dir)
+    except OSError as e:
+        return _error("delete_run", f"Failed to remove {run_dir}: {e}")
+
+    return ActionResult(
+        action="delete_run",
+        status=ActionStatus.SUCCESS,
+        message=f"Deleted run {run_id}",
+        data={"run_id": run_id, "bytes_removed": bytes_removed},
+        state_before=state_str,
+        state_after="",
     )
 
 

--- a/src/simctl/harness/claude.py
+++ b/src/simctl/harness/claude.py
@@ -51,6 +51,7 @@ _ALLOW_BASH: Final[tuple[str, ...]] = (
     "Bash(simctl config add-launcher*)",
     # Lifecycle move that does not delete data
     "Bash(simctl runs archive*)",
+    "Bash(simctl runs cancel*)",
     # Dev tooling
     "Bash(uv run pytest*)",
     "Bash(uv run ruff*)",
@@ -70,6 +71,7 @@ _ALLOW_BASH: Final[tuple[str, ...]] = (
 _ASK_BASH: Final[tuple[str, ...]] = (
     "Bash(simctl runs submit*)",  # spends HPC resources
     "Bash(simctl runs purge-work*)",  # deletes work/ files irreversibly
+    "Bash(simctl runs delete*)",  # removes run directory irreversibly
 )
 _DENY_BASH: Final[tuple[str, ...]] = (
     "Bash(rm -rf *)",

--- a/src/simctl/slurm/submit.py
+++ b/src/simctl/slurm/submit.py
@@ -80,6 +80,10 @@ class SlurmSubmitError(RuntimeError):
     """Raised when sbatch fails or returns unexpected output."""
 
 
+class SlurmCancelError(RuntimeError):
+    """Raised when scancel fails."""
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -156,6 +160,30 @@ def sbatch_submit(
         )
 
     return parse_job_id(result.stdout)
+
+
+def scancel_job(
+    job_id: str,
+    *,
+    runner: CommandRunner | None = None,
+) -> None:
+    """Cancel a Slurm job via ``scancel``.
+
+    Args:
+        job_id: The Slurm job ID to cancel.
+        runner: Optional callable that executes a command list and returns
+            a ``CommandResult``.  Defaults to the real subprocess runner.
+
+    Raises:
+        SlurmNotFoundError: If ``scancel`` is not on PATH.
+        SlurmCancelError: If scancel returns a non-zero exit code.
+    """
+    run = runner or _default_runner
+    result = run(["scancel", job_id])
+    if result.returncode != 0:
+        raise SlurmCancelError(
+            f"scancel failed (exit {result.returncode}):\n{result.stderr.strip()}"
+        )
 
 
 # Keep the old name as an alias so the existing test import still works,

--- a/tests/test_cli/test_manage.py
+++ b/tests/test_cli/test_manage.py
@@ -1,10 +1,11 @@
-"""Tests for simctl runs archive and runs purge-work commands."""
+"""Tests for simctl runs archive / purge-work / cancel / delete commands."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
+import pytest
 import tomli_w
 from typer.testing import CliRunner
 
@@ -18,6 +19,7 @@ def _create_run(
     run_id: str,
     *,
     status: str = "completed",
+    job_id: str = "",
 ) -> Path:
     """Create a minimal run directory with manifest.toml."""
     run_dir = parent / run_id
@@ -32,6 +34,8 @@ def _create_run(
             "status": status,
         },
     }
+    if job_id:
+        manifest["job"] = {"job_id": job_id}
     with open(run_dir / "manifest.toml", "wb") as f:
         tomli_w.dump(manifest, f)
     return run_dir
@@ -173,3 +177,112 @@ class TestPurgeWork:
         result = runner.invoke(app, ["runs", "purge-work", "--yes", str(run_dir)])
         assert result.exit_code == 0
         assert "Freed: 0.0 B" in result.output
+
+
+class TestDelete:
+    """Tests for `simctl runs delete`."""
+
+    @pytest.mark.parametrize("status", ["created", "cancelled", "failed"])
+    def test_delete_terminal_run_removes_directory(
+        self, tmp_path: Path, status: str
+    ) -> None:
+        """Created/cancelled/failed runs can be deleted."""
+        run_dir = _create_run(tmp_path, "R20260327-0001", status=status)
+        assert run_dir.exists()
+
+        result = runner.invoke(app, ["runs", "delete", "--yes", str(run_dir)])
+        assert result.exit_code == 0, result.output
+        assert "Deleted run R20260327-0001" in result.output
+        assert not run_dir.exists()
+
+    @pytest.mark.parametrize(
+        "status", ["submitted", "running", "completed", "archived"]
+    )
+    def test_delete_rejects_non_terminal_or_completed(
+        self, tmp_path: Path, status: str
+    ) -> None:
+        """Live or valuable runs are protected from accidental deletion."""
+        run_dir = _create_run(tmp_path, "R20260327-0001", status=status)
+
+        result = runner.invoke(app, ["runs", "delete", "--yes", str(run_dir)])
+        assert result.exit_code == 1
+        assert run_dir.exists()  # not removed
+
+    def test_delete_cancelled_without_confirmation(self, tmp_path: Path) -> None:
+        """User can decline the confirmation prompt."""
+        run_dir = _create_run(tmp_path, "R20260327-0001", status="cancelled")
+
+        result = runner.invoke(app, ["runs", "delete", str(run_dir)], input="n\n")
+        assert result.exit_code == 0
+        assert "Cancelled." in result.output
+        assert run_dir.exists()  # still there
+
+    def test_delete_nonexistent_run(self) -> None:
+        result = runner.invoke(app, ["runs", "delete", "/nonexistent/run"])
+        assert result.exit_code == 1
+
+
+class TestCancel:
+    """Tests for `simctl runs cancel`."""
+
+    def test_cancel_requires_active_state(self, tmp_path: Path) -> None:
+        run_dir = _create_run(
+            tmp_path, "R20260327-0001", status="completed", job_id="12345"
+        )
+        result = runner.invoke(app, ["runs", "cancel", "--yes", str(run_dir)])
+        assert result.exit_code == 1
+        assert "submitted/running" in result.output.lower()
+
+    def test_cancel_requires_job_id(self, tmp_path: Path) -> None:
+        run_dir = _create_run(tmp_path, "R20260327-0001", status="submitted")
+        result = runner.invoke(app, ["runs", "cancel", "--yes", str(run_dir)])
+        assert result.exit_code == 1
+        assert "job_id" in result.output.lower()
+
+    def test_cancel_running_calls_scancel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`runs cancel` invokes scancel and then sync."""
+        from simctl.core import actions
+        from simctl.slurm import submit as slurm_submit
+        from simctl.slurm.submit import CommandResult
+
+        run_dir = _create_run(
+            tmp_path, "R20260327-0001", status="running", job_id="98765"
+        )
+
+        scancel_calls: list[list[str]] = []
+
+        def fake_runner(cmd: list[str]) -> CommandResult:
+            scancel_calls.append(cmd)
+            return CommandResult(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(slurm_submit, "_default_runner", fake_runner)
+
+        # Stub sync_run so we don't actually talk to Slurm.
+        from simctl.core.actions import ActionResult, ActionStatus
+
+        def fake_sync(rd: Path) -> ActionResult:
+            return ActionResult(
+                action="sync_run",
+                status=ActionStatus.SUCCESS,
+                message="State: running -> cancelled",
+                data={"slurm_state": "CANCELLED"},
+                state_before="running",
+                state_after="cancelled",
+            )
+
+        monkeypatch.setattr(actions, "sync_run", fake_sync)
+
+        result = runner.invoke(app, ["runs", "cancel", "--yes", str(run_dir)])
+        assert result.exit_code == 0, result.output
+        assert any(cmd[:2] == ["scancel", "98765"] for cmd in scancel_calls)
+        assert "running -> cancelled" in result.output
+
+    def test_cancel_declined(self, tmp_path: Path) -> None:
+        run_dir = _create_run(
+            tmp_path, "R20260327-0001", status="running", job_id="98765"
+        )
+        result = runner.invoke(app, ["runs", "cancel", str(run_dir)], input="n\n")
+        assert result.exit_code == 0
+        assert "Cancelled." in result.output


### PR DESCRIPTION
## Summary

Two new run lifecycle commands prompted by real campaign operation.

### \`simctl runs cancel <run>\`
Atomic \`scancel + sync\`. Verifies the run is in \`submitted\`/\`running\` state, calls \`scancel <job_id>\` (via the new \`slurm.submit.scancel_job\` helper which reuses the existing \`CommandRunner\` abstraction), then immediately runs \`sync_run\` so the manifest reflects the cancellation. Replaces the manual two-step \`scancel <id> && simctl runs sync <run>\` workflow.

Mapped to a new \`cancel_run\` action (risk medium, non-destructive). Added to the allow list in the harness policy.

### \`simctl runs delete <run>\`
Hard-removes a run directory, gated to terminal non-completed states (\`created\`, \`cancelled\`, \`failed\`). Completed and archived runs are protected — they must go through the existing \`archive\` / \`purge-work\` flow so valuable results are never lost to a fat-fingered \`rm -rf\`.

Until now the only way to clean up bad sweeps was \`rm -rf\` from Bash, which (intentionally) hits the \`Bash(rm -rf *)\` deny rule, leaving the user stuck. \`runs delete\` provides the safe path.

Mapped to a new \`delete_run\` action (destructive, risk high, requires_confirmation). Added to the **ask** list in the harness policy alongside \`runs purge-work\` and \`runs submit\`.

## Why

These came up directly while running a 30-run survey:
- Cancelling a smoke test run after spotting a config bug took two commands and easy to forget the sync.
- Re-sweeping after a bug fix produced 10 stale run directories that I had to remove with \`find -depth -delete\` because \`rm -rf\` was denied — clearly a missing first-class operation.

## Test plan

- [x] 12 new tests in \`test_cli/test_manage.py\`:
  - \`TestDelete\` covers all 3 deletable states + all 4 protected states + decline + nonexistent
  - \`TestCancel\` covers state guard + missing job_id + scancel-then-sync (with mocked Slurm) + decline
- [x] \`uv run pytest tests/test_cli/test_manage.py\` → 25/25 pass
- [x] Full suite \`uv run pytest tests/\` → 663 pass
- [x] \`uv run ruff check\` and \`uv run mypy\` clean for the touched files