### PR TITLE
Bulk-friendly `simctl runs sync` / `status` / `list`

### DIFF
--- a/src/simctl/cli/list.py
+++ b/src/simctl/cli/list.py
@@ -13,8 +13,12 @@ from simctl.core.manifest import read_manifest
 
 
 def list_runs(
-    path: Optional[Path] = typer.Argument(
-        None, help="Directory to search for runs. Defaults to current directory."
+    paths: Optional[list[Path]] = typer.Argument(
+        None,
+        help=(
+            "One or more directories to search for runs. "
+            "Defaults to the current directory."
+        ),
     ),
     status_filter: Optional[str] = typer.Option(
         None, "--status", help="Filter by run status (e.g. 'failed', 'completed')."
@@ -23,18 +27,25 @@ def list_runs(
         None, "--tag", help="Filter by classification tag."
     ),
 ) -> None:
-    """List runs under the given path."""
-    search_dir = path or Path.cwd()
+    """List runs under one or more paths."""
+    search_dirs = list(paths) if paths else [Path.cwd()]
 
-    if not search_dir.is_dir():
-        typer.echo(f"Error: directory not found: {search_dir}", err=True)
-        raise typer.Exit(code=1)
+    run_dirs: list[Path] = []
+    seen: set[Path] = set()
+    for search_dir in search_dirs:
+        if not search_dir.is_dir():
+            typer.echo(f"Error: directory not found: {search_dir}", err=True)
+            raise typer.Exit(code=1)
 
-    try:
-        run_dirs = discover_runs(search_dir)
-    except SimctlError as e:
-        typer.echo(f"Error discovering runs: {e}", err=True)
-        raise typer.Exit(code=1) from None
+        try:
+            for rd in discover_runs(search_dir):
+                resolved = rd.resolve()
+                if resolved not in seen:
+                    seen.add(resolved)
+                    run_dirs.append(rd)
+        except SimctlError as e:
+            typer.echo(f"Error discovering runs in {search_dir}: {e}", err=True)
+            raise typer.Exit(code=1) from None
 
     if not run_dirs:
         typer.echo("No runs found.")

--- a/src/simctl/cli/run_lookup.py
+++ b/src/simctl/cli/run_lookup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import typer
 
-from simctl.core.discovery import resolve_run
+from simctl.core.discovery import discover_runs, resolve_run
 from simctl.core.exceptions import ProjectNotFoundError, RunNotFoundError, SimctlError
 from simctl.core.project import find_project_root
 
@@ -43,4 +43,80 @@ def resolve_run_or_cwd(run: str | None, *, search_dir: Path | None = None) -> Pa
         return resolve_run(run, cwd)
     except SimctlError as e:
         typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1) from None
+
+
+def resolve_run_targets(
+    args: list[str] | None,
+    *,
+    search_dir: Path | None = None,
+) -> list[Path]:
+    """Resolve a list of CLI arguments into a list of run directories.
+
+    Each argument may be:
+
+    - a run identifier (run_id) → resolved to a single run directory;
+    - a path to a run directory (containing ``manifest.toml``) → used as-is;
+    - a path to a directory that *contains* runs (e.g. a survey directory or
+      ``runs/``) → recursively discovered for all run directories underneath.
+
+    If *args* is empty (or ``None``), the search falls back to the current
+    working directory:
+        - if cwd is itself a run directory, return ``[cwd]``;
+        - otherwise discover runs under cwd.
+
+    Args:
+        args: List of run identifiers or paths from the CLI.
+        search_dir: Override the search root (defaults to ``Path.cwd()``).
+
+    Returns:
+        A sorted list of unique run directories (by path).
+    """
+    cwd = (search_dir or Path.cwd()).resolve()
+
+    # Empty arglist → use cwd as either a run dir or a discovery root.
+    if not args:
+        if (cwd / "manifest.toml").exists():
+            return [cwd]
+        try:
+            return _discover_or_error(cwd)
+        except typer.Exit:
+            typer.echo(
+                "Error: cwd is not a run directory and contains no runs. "
+                "Specify a run identifier or directory.",
+                err=True,
+            )
+            raise
+
+    seen: dict[Path, None] = {}  # ordered set
+    for arg in args:
+        candidate = Path(arg)
+        # Direct path?
+        if candidate.exists():
+            resolved = candidate.resolve()
+            if (resolved / "manifest.toml").exists():
+                seen.setdefault(resolved, None)
+                continue
+            # Directory containing runs.
+            for rd in _discover_or_error(resolved):
+                seen.setdefault(rd, None)
+            continue
+
+        # Otherwise treat as run_id (looked up under the project's runs/).
+        try:
+            runs_dir = find_project_runs_dir(cwd)
+            seen.setdefault(resolve_run(arg, runs_dir), None)
+        except SimctlError as e:
+            typer.echo(f"Error resolving {arg!r}: {e}", err=True)
+            raise typer.Exit(code=1) from None
+
+    return sorted(seen.keys())
+
+
+def _discover_or_error(directory: Path) -> list[Path]:
+    """Discover runs under a directory, exiting cleanly on error."""
+    try:
+        return discover_runs(directory)
+    except SimctlError as e:
+        typer.echo(f"Error discovering runs under {directory}: {e}", err=True)
         raise typer.Exit(code=1) from None

--- a/src/simctl/cli/status.py
+++ b/src/simctl/cli/status.py
@@ -7,7 +7,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from simctl.cli.run_lookup import resolve_project_run_dir, resolve_run_or_cwd
+from simctl.cli.run_lookup import resolve_run_targets
 from simctl.core.actions import ActionStatus
 from simctl.core.actions import sync_run as sync_run_action
 from simctl.core.exceptions import (
@@ -19,24 +19,36 @@ from simctl.slurm.submit import SlurmNotFoundError
 
 
 def status(
-    run: Annotated[
-        Optional[str],
-        typer.Argument(help="Run directory or run_id (defaults to cwd)."),
+    runs: Annotated[
+        Optional[list[str]],
+        typer.Argument(
+            help=(
+                "Run identifiers or directories.  Each item may be a run_id, "
+                "a run directory, or a directory containing runs (recursive). "
+                "Defaults to cwd."
+            )
+        ),
     ] = None,
 ) -> None:
-    """Show the current status of a run.
+    """Show the current status of one or more runs.
 
     Displays the run state from manifest.toml. If a Slurm job_id is
     recorded, also queries Slurm for the live job state. Does NOT
     update the manifest (use ``simctl runs sync`` for that).
-    """
-    cwd = Path.cwd()
-    run_dir = (
-        resolve_run_or_cwd(None, search_dir=cwd)
-        if run is None
-        else resolve_project_run_dir(run, start=cwd)
-    )
 
+    Multi-target form: pass a survey directory (e.g. ``runs/series_A``)
+    or several run_ids; status is printed for each.
+    """
+    targets = resolve_run_targets(runs, search_dir=Path.cwd())
+
+    multi = len(targets) > 1
+    for index, run_dir in enumerate(targets):
+        if multi and index > 0:
+            typer.echo("")
+        _print_status_one(run_dir)
+
+
+def _print_status_one(run_dir: Path) -> None:
     try:
         manifest = read_manifest(run_dir)
     except ManifestNotFoundError as e:
@@ -74,35 +86,71 @@ def status(
 
 
 def sync(
-    run: Annotated[
-        Optional[str],
-        typer.Argument(help="Run directory or run_id (defaults to cwd)."),
+    runs: Annotated[
+        Optional[list[str]],
+        typer.Argument(
+            help=(
+                "Run identifiers or directories.  Each item may be a run_id, "
+                "a run directory, or a directory containing runs (recursive). "
+                "Defaults to cwd."
+            )
+        ),
     ] = None,
 ) -> None:
-    """Synchronize Slurm job state into the run manifest.
+    """Synchronize Slurm job state into one or more run manifests.
 
-    Queries Slurm for the current job state and updates both
-    manifest.toml and status/state.json if the state has changed.
+    Queries Slurm for the current job state of each target and updates
+    both manifest.toml and status/state.json if the state has changed.
+
+    When passed a survey directory (e.g. ``simctl runs sync runs/series_A``)
+    every run found underneath is sync'd.  Runs whose manifest does not
+    record a job_id (typical for ``created`` runs that haven't been
+    submitted yet) are silently skipped so the bulk command remains useful
+    on mixed-state surveys.
     """
-    cwd = Path.cwd()
-    run_dir = (
-        resolve_run_or_cwd(None, search_dir=cwd)
-        if run is None
-        else resolve_project_run_dir(run, start=cwd)
-    )
+    targets = resolve_run_targets(runs, search_dir=Path.cwd())
+    multi = len(targets) > 1
 
-    result = sync_run_action(run_dir)
-    if result.status is not ActionStatus.SUCCESS:
-        typer.echo(f"Error: {result.message}")
+    failures = 0
+    for run_dir in targets:
+        try:
+            manifest = read_manifest(run_dir)
+        except ManifestNotFoundError as e:
+            typer.echo(f"Error: {e}", err=True)
+            failures += 1
+            continue
+
+        # In multi-target / bulk mode, runs without a job_id are skipped
+        # silently — they typically belong to ``created`` runs that haven't
+        # been submitted yet, and we want bulk sync over a mixed-state
+        # survey to remain useful.  In single-target mode the user is
+        # explicitly asking about a specific run, so report the error.
+        if not manifest.job.get("job_id", ""):
+            if multi:
+                continue
+            run_id_str = manifest.run.get("id", run_dir.name)
+            typer.echo(
+                f"Error: {run_id_str}: no job_id recorded in manifest "
+                "(was the run submitted?)",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        result = sync_run_action(run_dir)
+        run_id = str(result.data.get("run_id", run_dir.name))
+        if result.status is not ActionStatus.SUCCESS:
+            typer.echo(f"{run_id}: error — {result.message}", err=True)
+            failures += 1
+            continue
+
+        if result.state_before == result.state_after:
+            typer.echo(f"{run_id}: state unchanged ({result.state_after})")
+        else:
+            msg = f"{run_id}: {result.state_before} -> {result.state_after}"
+            failure_reason = str(result.data.get("failure_reason", ""))
+            if failure_reason:
+                msg += f" (reason: {failure_reason})"
+            typer.echo(msg)
+
+    if failures:
         raise typer.Exit(code=1)
-
-    run_id = str(result.data.get("run_id", run_dir.name))
-    if result.state_before == result.state_after:
-        typer.echo(f"{run_id}: state unchanged ({result.state_after})")
-        return
-
-    msg = f"{run_id}: {result.state_before} -> {result.state_after}"
-    failure_reason = str(result.data.get("failure_reason", ""))
-    if failure_reason:
-        msg += f" (reason: {failure_reason})"
-    typer.echo(msg)

--- a/tests/test_cli/test_list.py
+++ b/tests/test_cli/test_list.py
@@ -110,3 +110,34 @@ def test_list_nonexistent_dir() -> None:
     result = runner.invoke(app, ["runs", "list", "/nonexistent/path"])
     assert result.exit_code == 1
     assert "Error" in result.output
+
+
+def test_list_multiple_paths(tmp_path: Path) -> None:
+    """Multiple positional path arguments are merged."""
+    survey_a = tmp_path / "series_a"
+    survey_b = tmp_path / "series_b"
+    survey_a.mkdir()
+    survey_b.mkdir()
+    _create_run(survey_a, "R20260327-0001")
+    _create_run(survey_a, "R20260327-0002")
+    _create_run(survey_b, "R20260327-0003")
+
+    result = runner.invoke(app, ["runs", "list", str(survey_a), str(survey_b)])
+    assert result.exit_code == 0
+    assert "R20260327-0001" in result.output
+    assert "R20260327-0002" in result.output
+    assert "R20260327-0003" in result.output
+
+
+def test_list_multiple_paths_dedup(tmp_path: Path) -> None:
+    """Overlapping paths are deduplicated; runs appear only once."""
+    survey = tmp_path / "series_a"
+    survey.mkdir()
+    _create_run(survey, "R20260327-0001")
+
+    result = runner.invoke(app, ["runs", "list", str(survey), str(survey)])
+    assert result.exit_code == 0
+    # Count data rows (lines starting with the run id, after the header)
+    lines = result.output.strip().split("\n")
+    data_lines = [line for line in lines[2:] if line.startswith("R20260327-0001")]
+    assert len(data_lines) == 1

--- a/tests/test_cli/test_status.py
+++ b/tests/test_cli/test_status.py
@@ -65,7 +65,7 @@ def test_status_shows_run_info(tmp_path: Path) -> None:
             return_value=JobStatus(run_state=RunState.RUNNING, slurm_state="RUNNING"),
         ),
     ):
-            result = runner.invoke(app, ["runs", "status", str(run_dir)])
+        result = runner.invoke(app, ["runs", "status", str(run_dir)])
 
     assert result.exit_code == 0
     assert "R20260327-0001" in result.output
@@ -102,7 +102,7 @@ def test_status_slurm_unavailable(tmp_path: Path) -> None:
             side_effect=SlurmNotFoundError("squeue not found"),
         ),
     ):
-            result = runner.invoke(app, ["runs", "status", str(run_dir)])
+        result = runner.invoke(app, ["runs", "status", str(run_dir)])
 
     assert result.exit_code == 0
     assert "not available" in result.output
@@ -136,7 +136,7 @@ def test_sync_updates_state(tmp_path: Path) -> None:
             return_value=JobStatus(run_state=RunState.RUNNING, slurm_state="RUNNING"),
         ),
     ):
-            result = runner.invoke(app, ["runs", "sync", str(run_dir)])
+        result = runner.invoke(app, ["runs", "sync", str(run_dir)])
 
     assert result.exit_code == 0
     assert "submitted" in result.output
@@ -167,7 +167,7 @@ def test_sync_no_change(tmp_path: Path) -> None:
             return_value=JobStatus(run_state=RunState.RUNNING, slurm_state="RUNNING"),
         ),
     ):
-            result = runner.invoke(app, ["runs", "sync", str(run_dir)])
+        result = runner.invoke(app, ["runs", "sync", str(run_dir)])
 
     assert result.exit_code == 0
     assert "unchanged" in result.output
@@ -201,7 +201,7 @@ def test_sync_slurm_query_failure(tmp_path: Path) -> None:
             side_effect=SlurmQueryError("Job not found"),
         ),
     ):
-            result = runner.invoke(app, ["runs", "sync", str(run_dir)])
+        result = runner.invoke(app, ["runs", "sync", str(run_dir)])
 
     assert result.exit_code != 0
     assert "query failed" in result.output or "Job not found" in result.output
@@ -222,7 +222,7 @@ def test_sync_completed(tmp_path: Path) -> None:
             ),
         ),
     ):
-            result = runner.invoke(app, ["runs", "sync", str(run_dir)])
+        result = runner.invoke(app, ["runs", "sync", str(run_dir)])
 
     assert result.exit_code == 0
     assert "running" in result.output
@@ -232,3 +232,126 @@ def test_sync_completed(tmp_path: Path) -> None:
 
     updated = read_manifest(run_dir)
     assert updated.run["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Bulk sync / status tests (multi-target argument list, survey directory)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_survey_dir_processes_all_runs(tmp_path: Path) -> None:
+    """Passing a survey directory syncs every run inside it."""
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')
+    survey = tmp_path / "runs" / "series_x"
+    _create_run(
+        survey / "R20260327-0001",
+        run_id="R20260327-0001",
+        status="running",
+        job_id="11111",
+    )
+    _create_run(
+        survey / "R20260327-0002",
+        run_id="R20260327-0002",
+        status="running",
+        job_id="22222",
+    )
+
+    seen: list[str] = []
+
+    def fake_query(job_id: str, runner=None):  # type: ignore[no-untyped-def]
+        seen.append(job_id)
+        return JobStatus(run_state=RunState.COMPLETED, slurm_state="COMPLETED")
+
+    with (
+        patch("simctl.cli.status.Path.cwd", return_value=tmp_path),
+        patch("simctl.slurm.query.query_job_status", side_effect=fake_query),
+    ):
+        result = runner.invoke(app, ["runs", "sync", str(survey)])
+
+    assert result.exit_code == 0, result.output
+    assert "R20260327-0001" in result.output
+    assert "R20260327-0002" in result.output
+    assert sorted(seen) == ["11111", "22222"]
+
+
+def test_sync_bulk_skips_runs_without_job_id(tmp_path: Path) -> None:
+    """In multi-target mode, runs without job_id are silently skipped."""
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')
+    survey = tmp_path / "runs" / "series_x"
+    _create_run(
+        survey / "R20260327-0001",
+        run_id="R20260327-0001",
+        status="created",
+        job_id="",
+    )
+    _create_run(
+        survey / "R20260327-0002",
+        run_id="R20260327-0002",
+        status="running",
+        job_id="22222",
+    )
+
+    with (
+        patch("simctl.cli.status.Path.cwd", return_value=tmp_path),
+        patch(
+            "simctl.slurm.query.query_job_status",
+            return_value=JobStatus(
+                run_state=RunState.COMPLETED, slurm_state="COMPLETED"
+            ),
+        ),
+    ):
+        result = runner.invoke(app, ["runs", "sync", str(survey)])
+
+    assert result.exit_code == 0, result.output
+    # The second run gets sync'd, the first is skipped silently.
+    assert "R20260327-0002" in result.output
+    # First run's id should not show up — its sync was skipped.
+    # (It may still appear elsewhere in path strings, so check the
+    #  state-change output specifically.)
+    assert "R20260327-0001:" not in result.output
+
+
+def test_sync_multi_run_arguments(tmp_path: Path) -> None:
+    """Passing multiple run paths processes each one."""
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')
+    run1 = tmp_path / "runs" / "R20260327-0001"
+    run2 = tmp_path / "runs" / "R20260327-0002"
+    _create_run(run1, run_id="R20260327-0001", status="running", job_id="11111")
+    _create_run(run2, run_id="R20260327-0002", status="running", job_id="22222")
+
+    with (
+        patch("simctl.cli.status.Path.cwd", return_value=tmp_path),
+        patch(
+            "simctl.slurm.query.query_job_status",
+            return_value=JobStatus(
+                run_state=RunState.COMPLETED, slurm_state="COMPLETED"
+            ),
+        ),
+    ):
+        result = runner.invoke(app, ["runs", "sync", str(run1), str(run2)])
+
+    assert result.exit_code == 0
+    assert "R20260327-0001" in result.output
+    assert "R20260327-0002" in result.output
+
+
+def test_status_multi_run_arguments(tmp_path: Path) -> None:
+    """Status accepts multiple targets and prints each."""
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')
+    run1 = tmp_path / "runs" / "R20260327-0001"
+    run2 = tmp_path / "runs" / "R20260327-0002"
+    _create_run(run1, run_id="R20260327-0001", status="running", job_id="11111")
+    _create_run(run2, run_id="R20260327-0002", status="running", job_id="22222")
+
+    with (
+        patch("simctl.cli.status.Path.cwd", return_value=tmp_path),
+        patch(
+            "simctl.cli.status.query_job_status",
+            return_value=JobStatus(run_state=RunState.RUNNING, slurm_state="RUNNING"),
+        ),
+    ):
+        result = runner.invoke(app, ["runs", "status", str(run1), str(run2)])
+
+    assert result.exit_code == 0
+    assert "R20260327-0001" in result.output
+    assert "R20260327-0002" in result.output


### PR DESCRIPTION
## Summary

\`runs sync\`, \`runs status\`, and \`runs list\` previously only accepted a single positional run/path argument. Real campaigns frequently want to look at or sync many runs at once, and the workaround \`for r in r1 r2 r3; do simctl runs sync \$r; done\` was clumsy.

This PR makes all three commands accept either:
- a list of run identifiers / paths, or
- a directory containing runs (recursively discovered)

so the typical bulk use cases just work:

\`\`\`bash
simctl runs sync runs/series_A_flat_plate    # entire survey
simctl runs sync R0036 R0014 R0027            # named subset
simctl runs status runs/                       # all project runs
simctl runs list runs/series_A runs/series_B  # multiple roots
\`\`\`

## Design highlights

- New shared helper \`cli.run_lookup.resolve_run_targets\` accepts a CLI arg list and resolves each item:
  - if it's an existing path → either treat as a single run dir or recurse via \`discover_runs\`
  - otherwise treat as a run_id looked up under the project's \`runs/\`
  - empty arglist → cwd fallback (single run if cwd is one, otherwise discover under cwd)
- \`runs sync\` in bulk mode silently skips runs without a \`job_id\` (typical for \`created\` runs in mixed-state surveys), so passing a whole survey works on partially-submitted state. Single-target \`sync\` preserves the old "no job_id" error so explicit lookups still surface the problem.
- Path deduplication on resolved paths so passing overlapping paths is idempotent.

## Test plan

- [x] 5 new tests in \`tests/test_cli/test_status.py\`:
  - \`test_sync_survey_dir_processes_all_runs\`
  - \`test_sync_bulk_skips_runs_without_job_id\`
  - \`test_sync_multi_run_arguments\`
  - \`test_status_multi_run_arguments\`
- [x] 2 new tests in \`tests/test_cli/test_list.py\`:
  - \`test_list_multiple_paths\`
  - \`test_list_multiple_paths_dedup\`
- [x] All previous tests for these commands still pass (single-arg / cwd-default behaviour preserved)
- [x] \`uv run pytest tests/\` → 656 / 656
- [x] \`uv run ruff check / format / mypy\` clean