### PR TITLE
Add `simctl runs sweep --dry-run`

### DIFF
--- a/src/simctl/cli/create.py
+++ b/src/simctl/cli/create.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import typer
 
 from simctl.core.actions import ActionStatus, execute_action
+from simctl.core.case import JobData, load_case, resolve_case
 from simctl.core.exceptions import SimctlError
-from simctl.core.project import find_project_root
+from simctl.core.project import find_project_root, load_project
+from simctl.core.survey import expand_survey, generate_display_name, load_survey
 
 
 def _echo_warnings(warnings: list[str], *, context: str = "") -> None:
@@ -112,7 +114,150 @@ def sweep(
         Optional[Path],
         typer.Argument(help="Directory containing survey.toml (defaults to cwd)."),
     ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            "-n",
+            help=(
+                "Print the runs that would be generated (count, parameter "
+                "combinations, estimated total resource cost) without "
+                "writing any files."
+            ),
+        ),
+    ] = False,
 ) -> None:
-    """Generate all runs from a survey.toml parameter sweep."""
+    """Generate all runs from a survey.toml parameter sweep.
+
+    With ``--dry-run`` the survey is parsed and expanded but no run
+    directories are created — useful to verify the parameter combinations
+    and total resource cost before committing files / queue time.
+    """
     target = (survey_dir or Path.cwd()).resolve()
-    _create_survey(target)
+    if dry_run:
+        _sweep_dry_run(target)
+    else:
+        _create_survey(target)
+
+
+def _sweep_dry_run(survey_dir: Path) -> None:
+    """Print the planned runs without writing files."""
+    try:
+        survey_data = load_survey(survey_dir)
+    except SimctlError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    try:
+        project_root = find_project_root(survey_dir)
+    except SimctlError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    # Look up the base case so we can show the resolved job (the survey's
+    # own [job] block, when present, overrides the case's).
+    try:
+        project = load_project(project_root)
+        case_dir = resolve_case(survey_data.base_case, project.root_dir)
+        case_data = load_case(case_dir)
+    except SimctlError as exc:
+        typer.echo(f"Error resolving base case: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    effective_job = survey_data.job if survey_data.job.partition else case_data.job
+
+    combinations = expand_survey(survey_data.axes, survey_data.linked)
+    if not combinations:
+        typer.echo("No parameter combinations to expand.")
+        raise typer.Exit(code=0)
+
+    n = len(combinations)
+    typer.echo(f"[dry-run] {n} runs would be created in {survey_dir}")
+    typer.echo(f"  base case  : {survey_data.base_case}")
+    typer.echo(f"  simulator  : {survey_data.simulator}")
+    typer.echo(f"  launcher   : {survey_data.launcher}")
+    if survey_data.naming_template:
+        typer.echo(f"  display    : {survey_data.naming_template}")
+    typer.echo(_format_job_summary(effective_job))
+    typer.echo(_format_resource_estimate(effective_job, n))
+
+    # Print one line per combination so the user can scan parameters.
+    typer.echo("")
+    typer.echo("Planned runs:")
+    for combo in combinations:
+        display_name = generate_display_name(survey_data.naming_template, combo)
+        params_str = _format_combo(combo)
+        if display_name:
+            typer.echo(f"  {display_name:<24} {params_str}")
+        else:
+            typer.echo(f"  {params_str}")
+
+
+def _format_combo(combo: dict[str, Any]) -> str:
+    """Format a combo dict as ``key1=value1, key2=value2``."""
+    parts = []
+    for key in sorted(combo.keys()):
+        value = combo[key]
+        # Truncate long lists for readability.
+        if isinstance(value, list) and len(value) > 4:
+            shown = f"[{value[0]}, ..., {value[-1]} ({len(value)} items)]"
+        else:
+            shown = repr(value)
+        parts.append(f"{key}={shown}")
+    return ", ".join(parts)
+
+
+def _format_job_summary(job: JobData) -> str:
+    """Format a JobData line for the dry-run output."""
+    if job.processes > 1 or job.threads > 1 or job.cores > 1:
+        # rsc-style site
+        return (
+            f"  job        : partition={job.partition or '(default)'} "
+            f"p={job.processes} t={job.threads} c={job.cores} "
+            f"walltime={job.walltime}"
+        )
+    return (
+        f"  job        : partition={job.partition or '(default)'} "
+        f"nodes={job.nodes} ntasks={job.ntasks} walltime={job.walltime}"
+    )
+
+
+def _format_resource_estimate(job: JobData, n_runs: int) -> str:
+    """Best-effort estimate of total core-hours for the planned sweep."""
+    # Pick the larger of (rsc processes) or (standard ntasks) so the
+    # estimate works regardless of which site mode the job uses.
+    cores_per_run = max(job.processes, job.ntasks)
+    walltime_hours = _walltime_to_hours(job.walltime)
+    if cores_per_run <= 1 or walltime_hours <= 0:
+        return "  estimate   : (cannot estimate — incomplete job spec)"
+    total_core_hours = cores_per_run * walltime_hours * n_runs
+    return (
+        f"  estimate   : {n_runs} runs x {cores_per_run} cores x "
+        f"{walltime_hours:.1f} h walltime ~= {total_core_hours:,.0f} core-hours"
+    )
+
+
+def _walltime_to_hours(walltime: str) -> float:
+    """Parse a walltime string to hours.  Returns 0.0 on failure."""
+    if not walltime:
+        return 0.0
+    # Strip optional ``D-`` day prefix.
+    days = 0
+    rest = walltime
+    if "-" in walltime:
+        head, _, rest = walltime.partition("-")
+        try:
+            days = int(head)
+        except ValueError:
+            return 0.0
+    parts = rest.split(":")
+    try:
+        if len(parts) == 3:
+            h, m, s = (int(p) for p in parts)
+        elif len(parts) == 2:
+            h, m, s = 0, int(parts[0]), int(parts[1])
+        else:
+            return 0.0
+    except ValueError:
+        return 0.0
+    return days * 24 + h + m / 60 + s / 3600

--- a/tests/test_cli/test_create.py
+++ b/tests/test_cli/test_create.py
@@ -294,3 +294,74 @@ class TestSweep:
 
         assert manifest["origin"]["survey"] == "S20260327-test"
         assert set(manifest["variation"]["changed_keys"]) == {"nx", "ny"}
+
+    def test_sweep_dry_run_does_not_create_runs(self, tmp_path: Path) -> None:
+        """--dry-run prints planned runs and resource estimate without writing."""
+        project_dir = _make_project(tmp_path)
+        _make_case(project_dir, "base_case")
+        survey_dir = project_dir / "runs" / "my_survey"
+        _make_survey(survey_dir, "base_case")
+
+        result = runner.invoke(app, ["runs", "sweep", "--dry-run", str(survey_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert "[dry-run]" in result.output
+        assert "4 runs would be created" in result.output
+        assert "base_case" in result.output
+        # Resource estimate line.
+        assert "core-hours" in result.output
+
+        # No run directories should exist after dry-run.
+        run_dirs = [
+            d
+            for d in survey_dir.iterdir()
+            if d.is_dir() and (d / "manifest.toml").exists()
+        ]
+        assert run_dirs == []
+
+    def test_sweep_dry_run_lists_combinations(self, tmp_path: Path) -> None:
+        """--dry-run prints one line per planned run with its parameters."""
+        project_dir = _make_project(tmp_path)
+        _make_case(project_dir, "base_case")
+        survey_dir = project_dir / "runs" / "my_survey"
+        _make_survey(survey_dir, "base_case")
+
+        result = runner.invoke(app, ["runs", "sweep", "--dry-run", str(survey_dir)])
+
+        assert result.exit_code == 0, result.output
+        # Display names from the naming template should appear (as they
+        # would in a real sweep).
+        assert "nx32_ny32" in result.output
+        assert "nx64_ny64" in result.output
+        # Parameter values should be shown.
+        assert "nx=32" in result.output
+        assert "ny=64" in result.output
+
+    def test_sweep_dry_run_short_flag(self, tmp_path: Path) -> None:
+        """``-n`` is an accepted short alias for --dry-run."""
+        project_dir = _make_project(tmp_path)
+        _make_case(project_dir, "base_case")
+        survey_dir = project_dir / "runs" / "my_survey"
+        _make_survey(survey_dir, "base_case")
+
+        result = runner.invoke(app, ["runs", "sweep", "-n", str(survey_dir)])
+        assert result.exit_code == 0, result.output
+        assert "[dry-run]" in result.output
+
+        # No run directories should exist.
+        run_dirs = [
+            d
+            for d in survey_dir.iterdir()
+            if d.is_dir() and (d / "manifest.toml").exists()
+        ]
+        assert run_dirs == []
+
+    def test_sweep_dry_run_no_survey_toml(self, tmp_path: Path) -> None:
+        """--dry-run still surfaces missing survey.toml errors."""
+        project_dir = _make_project(tmp_path)
+        survey_dir = project_dir / "runs" / "empty_survey"
+        survey_dir.mkdir(parents=True)
+
+        result = runner.invoke(app, ["runs", "sweep", "--dry-run", str(survey_dir)])
+        assert result.exit_code == 1
+        assert "Error" in result.output


### PR DESCRIPTION
## Summary

Sweeps in real campaigns can be expensive — a 30-run survey at 1600 cores x 120 h walltime is roughly 5.8 M core-hours. Today the only way to preview what a sweep would create is to run it for real and inspect the resulting directories.

This PR adds \`--dry-run\` (with \`-n\` as the short alias) that loads the survey, resolves the base case, expands the parameter combinations, and prints a plan **without writing run directories**.

## Output example

\`\`\`
$ simctl runs sweep --dry-run runs/series_A_flat_plate
[dry-run] 10 runs would be created in runs/series_A_flat_plate
  base case  : flat_plate
  simulator  : emses
  launcher   : camphor
  display    : vti{path}
  job        : partition=hpa p=1600 t=1 c=1 walltime=120:00:00
  estimate   : 10 runs x 1600 cores x 120.0 h walltime ~= 1,920,000 core-hours

Planned runs:
  vti0.2668                species.1.path=0.2668, species.1.peth=0.2668
  vti0.5337                species.1.path=0.5337, species.1.peth=0.5337
  ...
\`\`\`

The job line picks the survey's \`[job]\` if present (matching what the real sweep would do) and falls back to the base case's \`[job]\` otherwise. The job formatter is RSC-mode-aware (camphor) — it shows \`p=N t=T c=C\` if any of those are set, otherwise \`nodes=N ntasks=N\`.

The walltime parser accepts \`HH:MM:SS\`, \`MM:SS\`, and \`D-HH:MM:SS\` so the estimate works on both standard and D-day jobs.

## Test plan

- [x] 4 new tests in \`tests/test_cli/test_create.py\`:
  - \`test_sweep_dry_run_does_not_create_runs\`
  - \`test_sweep_dry_run_lists_combinations\`
  - \`test_sweep_dry_run_short_flag\` (\`-n\`)
  - \`test_sweep_dry_run_no_survey_toml\` (errors still surface)
- [x] All existing sweep tests still pass
- [x] \`uv run pytest tests/\` → 654 / 654
- [x] \`uv run ruff check / format / mypy\` clean