### PR TITLE
Add `--watch` mode to `simctl runs jobs`

### DIFF
--- a/src/simctl/cli/jobs.py
+++ b/src/simctl/cli/jobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import time
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -23,6 +24,17 @@ def jobs(
         bool,
         typer.Option("--all", "-a", help="Show all runs, not just active jobs."),
     ] = False,
+    watch: Annotated[
+        Optional[float],
+        typer.Option(
+            "--watch",
+            "-w",
+            help=(
+                "Refresh the table every N seconds (clears screen between "
+                "refreshes).  Press Ctrl-C to stop."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """List active (submitted/running) jobs in the project.
 
@@ -31,6 +43,7 @@ def jobs(
     Examples:
       simctl runs jobs             # active jobs under cwd
       simctl runs jobs --all       # all runs with job info
+      simctl runs jobs -w 30       # auto-refresh every 30 seconds
     """
     search_dir = (path or Path.cwd()).resolve()
 
@@ -43,6 +56,14 @@ def jobs(
     except SimctlError:
         pass  # Use the given path
 
+    if watch is not None and watch > 0:
+        _watch_loop(search_dir, all_states=all_states, interval=watch)
+    else:
+        _print_jobs_once(search_dir, all_states=all_states)
+
+
+def _print_jobs_once(search_dir: Path, *, all_states: bool) -> None:
+    """Render the jobs table once and return without exiting on empty results."""
     try:
         run_dirs = discover_runs(search_dir)
     except SimctlError as e:
@@ -100,3 +121,25 @@ def jobs(
     # Summary
     active = sum(1 for r in rows if r[2] in active_states)
     typer.echo(f"\n{active} active, {len(rows)} total")
+
+
+def _watch_loop(search_dir: Path, *, all_states: bool, interval: float) -> None:
+    """Refresh the jobs view every ``interval`` seconds.
+
+    Uses a simple ANSI clear-screen between refreshes.  Stops on Ctrl-C
+    cleanly.
+    """
+    from datetime import datetime
+
+    try:
+        while True:
+            # ANSI: clear screen + move cursor home.
+            typer.echo("\x1b[2J\x1b[H", nl=False)
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            typer.echo(f"simctl runs jobs (watch every {interval:g}s) — {timestamp}")
+            typer.echo("")
+            _print_jobs_once(search_dir, all_states=all_states)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        typer.echo("\nStopped.")
+        raise typer.Exit(code=0) from None

--- a/tests/test_cli/test_jobs.py
+++ b/tests/test_cli/test_jobs.py
@@ -1,0 +1,167 @@
+"""Tests for `simctl runs jobs` (including the new --watch loop)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import tomli_w
+from typer.testing import CliRunner
+
+from simctl.cli.main import app
+
+if TYPE_CHECKING:
+    import pytest
+
+runner = CliRunner()
+
+
+def _make_project(tmp_path: Path) -> Path:
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test-project"\n')
+    (tmp_path / "cases").mkdir()
+    (tmp_path / "runs").mkdir()
+    return tmp_path
+
+
+def _create_run(
+    parent: Path,
+    run_id: str,
+    *,
+    status: str,
+    job_id: str = "",
+    submitted_at: str = "",
+) -> Path:
+    """Create a minimal run directory with manifest.toml under ``parent``."""
+    run_dir = parent / run_id
+    run_dir.mkdir(parents=True)
+    manifest: dict[str, Any] = {
+        "run": {
+            "id": run_id,
+            "display_name": f"d_{run_id}",
+            "status": status,
+        },
+        "job": {
+            "scheduler": "slurm",
+            "job_id": job_id,
+            "submitted_at": submitted_at,
+        },
+    }
+    with open(run_dir / "manifest.toml", "wb") as f:
+        tomli_w.dump(manifest, f)
+    return run_dir
+
+
+class TestJobs:
+    """Tests for the basic (non-watch) jobs command."""
+
+    def test_jobs_lists_active_runs(self, tmp_path: Path) -> None:
+        project_dir = _make_project(tmp_path)
+        _create_run(
+            project_dir / "runs",
+            "R20260327-0001",
+            status="running",
+            job_id="11111",
+            submitted_at="2026-03-27T10:00:00+09:00",
+        )
+        _create_run(
+            project_dir / "runs",
+            "R20260327-0002",
+            status="completed",
+            job_id="22222",
+        )
+
+        result = runner.invoke(app, ["runs", "jobs", str(project_dir)])
+        assert result.exit_code == 0
+        assert "R20260327-0001" in result.output
+        # Completed runs are not 'active', so should be hidden by default.
+        assert "R20260327-0002" not in result.output
+        assert "11111" in result.output
+
+    def test_jobs_all_includes_completed(self, tmp_path: Path) -> None:
+        project_dir = _make_project(tmp_path)
+        _create_run(
+            project_dir / "runs",
+            "R20260327-0001",
+            status="completed",
+            job_id="22222",
+        )
+
+        result = runner.invoke(app, ["runs", "jobs", "--all", str(project_dir)])
+        assert result.exit_code == 0
+        assert "R20260327-0001" in result.output
+        assert "completed" in result.output
+
+    def test_jobs_no_runs(self, tmp_path: Path) -> None:
+        _make_project(tmp_path)
+        result = runner.invoke(app, ["runs", "jobs", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No runs found." in result.output
+
+
+class TestWatchLoop:
+    """Tests for the --watch refresh loop."""
+
+    def test_watch_calls_print_repeatedly_then_stops(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The watch loop refreshes until KeyboardInterrupt, then exits cleanly."""
+        from simctl.cli import jobs as jobs_cli
+
+        project_dir = _make_project(tmp_path)
+        _create_run(
+            project_dir / "runs",
+            "R20260327-0001",
+            status="running",
+            job_id="11111",
+        )
+
+        call_count = {"n": 0}
+
+        def fake_print_once(search_dir: Path, *, all_states: bool) -> None:
+            call_count["n"] += 1
+            jobs_cli.typer.echo(f"call {call_count['n']}")
+
+        def fake_sleep(seconds: float) -> None:
+            # Simulate the user pressing Ctrl-C after the second refresh.
+            if call_count["n"] >= 2:
+                raise KeyboardInterrupt
+            # No actual sleep — keep the test fast.
+
+        monkeypatch.setattr(jobs_cli, "_print_jobs_once", fake_print_once)
+        monkeypatch.setattr(jobs_cli.time, "sleep", fake_sleep)
+
+        result = runner.invoke(
+            app, ["runs", "jobs", "--watch", "0.01", str(project_dir)]
+        )
+        assert result.exit_code == 0, result.output
+        assert call_count["n"] >= 2
+        assert "Stopped." in result.output
+
+    def test_watch_short_alias_w(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``-w`` is an accepted short alias for --watch."""
+        from simctl.cli import jobs as jobs_cli
+
+        project_dir = _make_project(tmp_path)
+        _create_run(
+            project_dir / "runs",
+            "R20260327-0001",
+            status="running",
+            job_id="11111",
+        )
+
+        seen = {"called": False}
+
+        def fake_print_once(search_dir: Path, *, all_states: bool) -> None:
+            seen["called"] = True
+
+        def fake_sleep(seconds: float) -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(jobs_cli, "_print_jobs_once", fake_print_once)
+        monkeypatch.setattr(jobs_cli.time, "sleep", fake_sleep)
+
+        result = runner.invoke(app, ["runs", "jobs", "-w", "0.01", str(project_dir)])
+        assert result.exit_code == 0
+        assert seen["called"]


### PR DESCRIPTION
## Summary

\`simctl runs jobs\` is the project-wide active-jobs view. When managing a survey of dozens of long-running runs the natural workflow is to keep the table refreshing in the background — currently the user has to wrap the command in \`watch -n 30 ...\` from the shell, which loses simctl's coloured output and produces an awkward layout.

This PR adds a built-in \`--watch\` (short \`-w\`) option that takes a refresh interval in seconds and loops until interrupted with Ctrl-C:

\`\`\`bash
simctl runs jobs -w 30           # refresh every 30 seconds
simctl runs jobs --all -w 60     # all runs, every 60 seconds
\`\`\`

The loop clears the terminal between refreshes (ANSI \`\\x1b[2J\\x1b[H\`) and stamps the current time so the user can tell at a glance how stale the snapshot is. Ctrl-C exits cleanly with code 0 and a "Stopped." message.

Refactored the existing render path into \`_print_jobs_once\` so the single-shot and watch flows share code.

## Test plan

- [x] New \`tests/test_cli/test_jobs.py\` with 5 tests:
  - Active filter (\`TestJobs::test_jobs_lists_active_runs\`)
  - \`--all\` includes completed (\`TestJobs::test_jobs_all_includes_completed\`)
  - Empty project (\`TestJobs::test_jobs_no_runs\`)
  - Watch loop refreshes until KeyboardInterrupt and exits cleanly (\`TestWatchLoop::test_watch_calls_print_repeatedly_then_stops\`) — \`time.sleep\` is monkeypatched to raise after the second refresh
  - \`-w\` short alias works (\`TestWatchLoop::test_watch_short_alias_w\`)
- [x] All other tests still pass: 655 / 655
- [x] \`uv run ruff check / format / mypy\` clean