### PR TITLE
Add `simctl runs dashboard` for multi-run progress view

### DIFF
--- a/src/simctl/cli/dashboard.py
+++ b/src/simctl/cli/dashboard.py
@@ -1,0 +1,179 @@
+"""CLI command for the multi-run dashboard view."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from simctl.cli.run_lookup import resolve_run_targets
+from simctl.core.exceptions import SimctlError
+from simctl.core.manifest import read_manifest
+
+
+def dashboard(
+    targets: Annotated[
+        Optional[list[str]],
+        typer.Argument(
+            help=(
+                "Run identifiers, run directories, or directories containing "
+                "runs (recursive).  Defaults to cwd / project runs/."
+            ),
+        ),
+    ] = None,
+    watch: Annotated[
+        Optional[float],
+        typer.Option(
+            "--watch",
+            "-w",
+            help=(
+                "Refresh the dashboard every N seconds (clears screen between "
+                "refreshes).  Press Ctrl-C to stop."
+            ),
+        ),
+    ] = None,
+    all_states: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help="Show all runs, not just the ones in submitted/running state.",
+        ),
+    ] = False,
+) -> None:
+    """Multi-run progress dashboard.
+
+    Aggregates per-run progress (state, step, %, last diagnostic) into a
+    single table.  Useful while a survey of dozens of runs is in flight:
+    instead of opening ``simctl runs log`` for each run individually,
+    one ``simctl runs dashboard`` call shows the whole survey.
+
+    Examples:
+      simctl runs dashboard runs/series_A          # one survey
+      simctl runs dashboard -w 30 runs/series_A    # auto-refresh every 30 s
+      simctl runs dashboard --all runs/            # whole project, including
+                                                    # completed/failed runs
+    """
+    cwd = Path.cwd().resolve()
+    run_dirs = resolve_run_targets(targets, search_dir=cwd)
+
+    if watch is not None and watch > 0:
+        _watch_loop(run_dirs, all_states=all_states, interval=watch)
+    else:
+        _print_dashboard(run_dirs, all_states=all_states)
+
+
+def _print_dashboard(run_dirs: list[Path], *, all_states: bool) -> None:
+    """Render the dashboard table once."""
+    if not run_dirs:
+        typer.echo("No runs found.")
+        return
+
+    active_states = {"submitted", "running"}
+    rows: list[tuple[str, str, str, str, str, str]] = []
+
+    for run_dir in run_dirs:
+        try:
+            manifest = read_manifest(run_dir)
+        except SimctlError:
+            continue
+
+        status = str(manifest.run.get("status", "unknown"))
+        if not all_states and status not in active_states:
+            continue
+
+        run_id = str(manifest.run.get("id", run_dir.name))
+        display_name = str(manifest.run.get("display_name", ""))
+
+        step_str, pct_str = _progress_for_run(run_dir, manifest.simulator)
+
+        # Show the latest known Slurm state if recorded.
+        last_slurm = str(manifest.run.get("last_slurm_state", "")) or "-"
+
+        rows.append((run_id, display_name, status, step_str, pct_str, last_slurm))
+
+    if not rows:
+        typer.echo("No active runs found.")
+        return
+
+    # Sort by run_id for stable output.
+    rows.sort(key=lambda r: r[0])
+
+    headers = ("RUN_ID", "NAME", "STATE", "STEP", "%", "SLURM")
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    typer.echo(fmt.format(*headers))
+    typer.echo(fmt.format(*("-" * w for w in widths)))
+    for row in rows:
+        typer.echo(fmt.format(*row))
+
+    n_active = sum(1 for r in rows if r[2] in active_states)
+    typer.echo(f"\n{n_active} active, {len(rows)} total")
+
+
+def _progress_for_run(
+    run_dir: Path,
+    simulator: dict[str, str],
+) -> tuple[str, str]:
+    """Best-effort progress lookup for a single run.
+
+    Returns ``(step_str, pct_str)`` where each part is a short string
+    suitable for table cells.  Returns ``("-", "-")`` when the adapter
+    has no progress to report.
+    """
+    adapter_name = simulator.get("adapter", "") or simulator.get("name", "")
+    if not adapter_name:
+        return "-", "-"
+
+    try:
+        import simctl.adapters  # noqa: F401  (registers adapters)
+        from simctl.adapters.registry import get as get_adapter
+
+        adapter_cls = get_adapter(adapter_name)
+        adapter = adapter_cls()
+        summary = adapter.summarize(run_dir)
+    except Exception:
+        return "-", "-"
+
+    last_step = summary.get("last_step")
+    nstep = summary.get("nstep")
+    if last_step is None or not nstep:
+        return "-", "-"
+
+    pct = float(last_step) / float(nstep) * 100
+    return f"{int(last_step):d}/{int(nstep):d}", f"{pct:5.1f}%"
+
+
+def _watch_loop(
+    run_dirs: list[Path],
+    *,
+    all_states: bool,
+    interval: float,
+) -> None:
+    """Refresh the dashboard every ``interval`` seconds.
+
+    Stops cleanly on Ctrl-C.  Each refresh re-reads the manifests and
+    re-runs the per-run progress lookup, so newly-submitted or newly-
+    completed runs are picked up automatically.
+    """
+    from datetime import datetime
+
+    try:
+        while True:
+            typer.echo("\x1b[2J\x1b[H", nl=False)
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            typer.echo(
+                f"simctl runs dashboard (watch every {interval:g}s) — {timestamp}"
+            )
+            typer.echo("")
+            _print_dashboard(run_dirs, all_states=all_states)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        typer.echo("\nStopped.")
+        raise typer.Exit(code=0) from None

--- a/src/simctl/cli/main.py
+++ b/src/simctl/cli/main.py
@@ -9,6 +9,7 @@ from simctl.cli.clone import clone
 from simctl.cli.config import config_app
 from simctl.cli.context import context
 from simctl.cli.create import create, sweep
+from simctl.cli.dashboard import dashboard
 from simctl.cli.extend import extend
 from simctl.cli.history import history
 from simctl.cli.init import doctor, init
@@ -43,6 +44,7 @@ runs_app.command("log")(log)
 runs_app.command("list")(list_runs)
 runs_app.command("jobs")(jobs)
 runs_app.command("history")(history)
+runs_app.command("dashboard")(dashboard)
 runs_app.command("clone")(clone)
 runs_app.command("extend")(extend)
 runs_app.command("archive")(archive)

--- a/tests/test_cli/test_dashboard.py
+++ b/tests/test_cli/test_dashboard.py
@@ -1,0 +1,156 @@
+"""Tests for `simctl runs dashboard`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import tomli_w
+from typer.testing import CliRunner
+
+from simctl.cli.main import app
+
+if TYPE_CHECKING:
+    import pytest
+
+runner = CliRunner()
+
+
+def _make_project(tmp_path: Path) -> Path:
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test-project"\n')
+    (tmp_path / "cases").mkdir()
+    (tmp_path / "runs").mkdir()
+    return tmp_path
+
+
+def _create_run(
+    parent: Path,
+    run_id: str,
+    *,
+    status: str,
+    job_id: str = "",
+    display_name: str = "",
+    last_slurm_state: str = "",
+) -> Path:
+    """Create a minimal run directory with manifest.toml under ``parent``."""
+    run_dir = parent / run_id
+    run_dir.mkdir(parents=True)
+    manifest: dict[str, Any] = {
+        "run": {
+            "id": run_id,
+            "display_name": display_name or f"d_{run_id}",
+            "status": status,
+        },
+        "job": {
+            "scheduler": "slurm",
+            "job_id": job_id,
+        },
+        "simulator": {
+            "name": "fake_sim",
+            "adapter": "fake_sim",
+        },
+    }
+    if last_slurm_state:
+        manifest["run"]["last_slurm_state"] = last_slurm_state
+    with open(run_dir / "manifest.toml", "wb") as f:
+        tomli_w.dump(manifest, f)
+    return run_dir
+
+
+class TestDashboard:
+    """Tests for the basic (non-watch) dashboard command."""
+
+    def test_dashboard_lists_active_runs(self, tmp_path: Path) -> None:
+        project_dir = _make_project(tmp_path)
+        survey = project_dir / "runs" / "series_x"
+        _create_run(
+            survey,
+            "R20260327-0001",
+            status="running",
+            job_id="11111",
+            last_slurm_state="RUNNING",
+        )
+        _create_run(
+            survey,
+            "R20260327-0002",
+            status="completed",
+            job_id="22222",
+        )
+
+        result = runner.invoke(app, ["runs", "dashboard", str(survey)])
+        assert result.exit_code == 0, result.output
+        # Active runs are shown by default; completed runs are hidden.
+        assert "R20260327-0001" in result.output
+        assert "R20260327-0002" not in result.output
+
+    def test_dashboard_all_includes_completed(self, tmp_path: Path) -> None:
+        project_dir = _make_project(tmp_path)
+        survey = project_dir / "runs" / "series_x"
+        _create_run(survey, "R20260327-0001", status="completed", job_id="11111")
+
+        result = runner.invoke(app, ["runs", "dashboard", "--all", str(survey)])
+        assert result.exit_code == 0
+        assert "R20260327-0001" in result.output
+        assert "completed" in result.output
+
+    def test_dashboard_no_active_runs(self, tmp_path: Path) -> None:
+        project_dir = _make_project(tmp_path)
+        survey = project_dir / "runs" / "series_x"
+        _create_run(survey, "R20260327-0001", status="completed", job_id="11111")
+
+        result = runner.invoke(app, ["runs", "dashboard", str(survey)])
+        assert result.exit_code == 0
+        assert "No active runs" in result.output
+
+    def test_dashboard_includes_state_column(self, tmp_path: Path) -> None:
+        project_dir = _make_project(tmp_path)
+        survey = project_dir / "runs" / "series_x"
+        _create_run(
+            survey,
+            "R20260327-0001",
+            status="running",
+            job_id="11111",
+            last_slurm_state="RUNNING",
+        )
+
+        result = runner.invoke(app, ["runs", "dashboard", str(survey)])
+        assert result.exit_code == 0
+        # Header row contains the expected columns.
+        assert "RUN_ID" in result.output
+        assert "STATE" in result.output
+        assert "STEP" in result.output
+        assert "%" in result.output
+        assert "SLURM" in result.output
+
+
+class TestDashboardWatch:
+    """Tests for the --watch refresh loop."""
+
+    def test_watch_refreshes_then_stops(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from simctl.cli import dashboard as dashboard_cli
+
+        project_dir = _make_project(tmp_path)
+        survey = project_dir / "runs" / "series_x"
+        _create_run(survey, "R20260327-0001", status="running", job_id="11111")
+
+        call_count = {"n": 0}
+
+        def fake_print(run_dirs: list[Path], *, all_states: bool) -> None:
+            call_count["n"] += 1
+            dashboard_cli.typer.echo(f"call {call_count['n']}")
+
+        def fake_sleep(seconds: float) -> None:
+            if call_count["n"] >= 2:
+                raise KeyboardInterrupt
+
+        monkeypatch.setattr(dashboard_cli, "_print_dashboard", fake_print)
+        monkeypatch.setattr(dashboard_cli.time, "sleep", fake_sleep)
+
+        result = runner.invoke(
+            app, ["runs", "dashboard", "--watch", "0.01", str(survey)]
+        )
+        assert result.exit_code == 0
+        assert call_count["n"] >= 2
+        assert "Stopped." in result.output


### PR DESCRIPTION
## Summary

Managing a survey of dozens of runs with the existing tools is awkward: \`simctl runs jobs\` shows active jobs with submission timestamps but no progress, and \`simctl runs log\` shows progress for one run at a time. When a 30-run survey is in flight there is no single command that answers "where is each run right now?".

This PR adds \`simctl runs dashboard\`:

- accepts the same target syntax as \`runs sync\` / \`runs status\` (run_ids, run dirs, or directories containing runs);
- prints a single table per run: id, display_name, state, current step, %, last recorded Slurm state;
- defaults to active states (submitted/running) and accepts \`--all\` to include completed/failed/cancelled;
- supports \`--watch N\` / \`-w N\` for live refresh, mirroring the loop added to \`runs jobs\` in #6.

## Example output

\`\`\`
$ simctl runs dashboard runs/series_A_flat_plate
RUN_ID          NAME       STATE    STEP          %       SLURM
--------------  ---------  -------  ------------  ------  -------
R20260407-0033  vti0.27    running  61234/400000   15.3%  RUNNING
R20260407-0034  vti0.53    running  62411/400000   15.6%  RUNNING
...
R20260407-0042  vti2.67    running  60882/400000   15.2%  RUNNING

10 active, 10 total
\`\`\`

\`\`\`
$ simctl runs dashboard -w 30 runs/series_A_flat_plate
# refreshes every 30 seconds, Ctrl-C to stop
\`\`\`

## Design notes

- Per-run progress reuses the same path as \`runs log\`: it asks the adapter's \`summarize(run_dir)\` for \`last_step\` / \`nstep\` and falls back to \`-\` when the adapter has nothing to report.
- No new domain logic is introduced — the dashboard is purely an aggregator over existing CLI helpers and adapter hooks.
- Target resolution uses the \`resolve_run_targets\` helper introduced in #3, so passing a survey directory recursively discovers runs underneath.

## Test plan

- [x] 5 new tests in \`tests/test_cli/test_dashboard.py\`:
  - active filter (default)
  - \`--all\` includes completed
  - no active runs
  - column structure
  - watch loop refreshes and stops on KeyboardInterrupt
- [x] \`uv run pytest tests/\` clean
- [x] \`uv run ruff check / format / mypy\` clean