### PR TITLE
Skip terminal-state runs in bulk `runs sync`

### DIFF
--- a/src/simctl/cli/status.py
+++ b/src/simctl/cli/status.py
@@ -14,6 +14,7 @@ from simctl.core.exceptions import (
     ManifestNotFoundError,
 )
 from simctl.core.manifest import read_manifest
+from simctl.core.state import RunState
 from simctl.slurm.query import SlurmQueryError, query_job_status
 from simctl.slurm.submit import SlurmNotFoundError
 
@@ -103,13 +104,30 @@ def sync(
     both manifest.toml and status/state.json if the state has changed.
 
     When passed a survey directory (e.g. ``simctl runs sync runs/series_A``)
-    every run found underneath is sync'd.  Runs whose manifest does not
-    record a job_id (typical for ``created`` runs that haven't been
-    submitted yet) are silently skipped so the bulk command remains useful
-    on mixed-state surveys.
+    every run found underneath is sync'd.  In bulk / multi-target mode the
+    following runs are skipped silently so the command remains useful on
+    mixed-state surveys:
+
+    - runs without a recorded ``job_id`` (typical for ``created`` runs that
+      haven't been submitted yet);
+    - runs already in a terminal state (``completed``, ``failed``,
+      ``cancelled``, ``archived``, ``purged``) — those have nothing left to
+      sync.
+
+    In single-target mode the user is explicitly asking about a specific
+    run, so the precondition errors are surfaced instead of swallowed.
     """
     targets = resolve_run_targets(runs, search_dir=Path.cwd())
     multi = len(targets) > 1
+
+    # Terminal states that no longer need (or accept) Slurm reconciliation.
+    terminal_states = {
+        RunState.COMPLETED.value,
+        RunState.FAILED.value,
+        RunState.CANCELLED.value,
+        RunState.ARCHIVED.value,
+        RunState.PURGED.value,
+    }
 
     failures = 0
     for run_dir in targets:
@@ -122,9 +140,7 @@ def sync(
 
         # In multi-target / bulk mode, runs without a job_id are skipped
         # silently — they typically belong to ``created`` runs that haven't
-        # been submitted yet, and we want bulk sync over a mixed-state
-        # survey to remain useful.  In single-target mode the user is
-        # explicitly asking about a specific run, so report the error.
+        # been submitted yet.
         if not manifest.job.get("job_id", ""):
             if multi:
                 continue
@@ -135,6 +151,21 @@ def sync(
                 err=True,
             )
             raise typer.Exit(code=1)
+
+        # Same idea for runs already in a terminal state — there is nothing
+        # for sync_run() to do, and the underlying action raises a
+        # precondition_failed for completed/failed/cancelled.  Skip silently
+        # in bulk mode so the rest of the survey still gets processed.
+        current_state = str(manifest.run.get("status", ""))
+        if current_state in terminal_states:
+            if multi:
+                continue
+            run_id_str = manifest.run.get("id", run_dir.name)
+            typer.echo(
+                f"{run_id_str}: state already terminal ({current_state}) — "
+                "nothing to sync"
+            )
+            continue
 
         result = sync_run_action(run_dir)
         run_id = str(result.data.get("run_id", run_dir.name))

--- a/tests/test_cli/test_status.py
+++ b/tests/test_cli/test_status.py
@@ -335,6 +335,70 @@ def test_sync_multi_run_arguments(tmp_path: Path) -> None:
     assert "R20260327-0002" in result.output
 
 
+def test_sync_bulk_skips_terminal_states(tmp_path: Path) -> None:
+    """In multi-target mode, completed/failed/cancelled runs are skipped silently.
+
+    Without this skip, ``sync_run_action`` raises a precondition_failed
+    error for terminal states (it only accepts submitted/running) and
+    ``simctl runs sync runs/`` would error out the moment any run in the
+    survey has finished — exactly the wrong behaviour for monitoring a
+    long survey.
+    """
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')
+    survey = tmp_path / "runs" / "series_x"
+    _create_run(
+        survey / "R20260327-0001",
+        run_id="R20260327-0001",
+        status="completed",
+        job_id="11111",
+    )
+    _create_run(
+        survey / "R20260327-0002",
+        run_id="R20260327-0002",
+        status="running",
+        job_id="22222",
+    )
+    _create_run(
+        survey / "R20260327-0003",
+        run_id="R20260327-0003",
+        status="failed",
+        job_id="33333",
+    )
+
+    with (
+        patch("simctl.cli.status.Path.cwd", return_value=tmp_path),
+        patch(
+            "simctl.slurm.query.query_job_status",
+            return_value=JobStatus(
+                run_state=RunState.COMPLETED, slurm_state="COMPLETED"
+            ),
+        ),
+    ):
+        result = runner.invoke(app, ["runs", "sync", str(survey)])
+
+    assert result.exit_code == 0, result.output
+    # Only the running run goes through the sync action.
+    assert "R20260327-0002" in result.output
+    # The completed and failed runs are skipped silently — their lines
+    # should not appear as state-change records.
+    assert "R20260327-0001:" not in result.output
+    assert "R20260327-0003:" not in result.output
+
+
+def test_sync_single_terminal_run_reports_skip(tmp_path: Path) -> None:
+    """Single-target sync of a terminal run prints a skip notice (no error)."""
+    (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')
+    run_dir = tmp_path / "runs" / "R20260327-0001"
+    _create_run(run_dir, status="completed", job_id="11111")
+
+    with patch("simctl.cli.status.Path.cwd", return_value=tmp_path):
+        result = runner.invoke(app, ["runs", "sync", str(run_dir)])
+
+    assert result.exit_code == 0
+    assert "completed" in result.output
+    assert "nothing to sync" in result.output
+
+
 def test_status_multi_run_arguments(tmp_path: Path) -> None:
     """Status accepts multiple targets and prints each."""
     (tmp_path / "simproject.toml").write_text('[project]\nname = "test"\n')


### PR DESCRIPTION
## Summary

In multi-target mode (e.g. \`simctl runs sync runs/\` over a whole project), the existing skip logic only handled runs without a \`job_id\`. Runs already in a terminal state (completed / failed / cancelled / archived / purged) still went through the precondition check inside \`sync_run_action\`, which fails because that action only accepts submitted/running. The bulk command then errored out on the very first finished run in the survey — exactly the wrong behaviour for monitoring a long-running campaign where some runs finish ahead of others.

## Why this matters

This was hit immediately during the ion_depression smoke-test phase: 5 of 30 runs completed early, and \`simctl runs sync runs/\` started reporting "Run state is 'completed', requires one of: submitted, running" for each completed run, polluting the bulk output and giving exit code 1.

## Fix

Extend the bulk-mode skip to also bypass terminal-state runs.

- **Multi-target form** (\`simctl runs sync runs/\`, \`simctl runs sync runs/series_A runs/series_B\`, …): skip terminal-state runs silently and continue processing the rest. The exit code still reflects any real failures (Slurm query errors etc.) on the runs that *do* need syncing.
- **Single-target form** (\`simctl runs sync R20260407-0036\`): print a short notice \`state already terminal (completed) — nothing to sync\` and exit 0. No more confusing precondition error for the user who explicitly asked.

The same idea (bulk-friendly skip) already governs the \`no job_id\` case from #3.

## Test plan

- [x] \`tests/test_cli/test_status.py::test_sync_bulk_skips_terminal_states\` — 3-run survey with completed/running/failed; only the running run is processed.
- [x] \`tests/test_cli/test_status.py::test_sync_single_terminal_run_reports_skip\` — single completed run produces a friendly skip notice instead of exit 1.
- [x] All existing sync tests still pass: \`uv run pytest tests/\` → 691 / 691.
- [x] \`uv run ruff check / format / mypy\` clean.