### PR TITLE
fix: harden update-harness re-exec against module shadowing

### DIFF
--- a/src/runops/cli/update_harness.py
+++ b/src/runops/cli/update_harness.py
@@ -119,8 +119,8 @@ def _pull_tools_repo(project_dir: Path) -> str | None:
 
 def _restart_with_skip_pull() -> None:
     """Re-exec ``update-harness`` so the pulled editable install is reloaded."""
-    argv = [sys.executable, "-m", "runops.cli.main", *sys.argv[1:]]
-    if "--skip-pull" not in argv[3:]:
+    argv = [sys.executable, "-I", "-m", "runops.cli.main", *sys.argv[1:]]
+    if "--skip-pull" not in argv[4:]:
         argv.append("--skip-pull")
 
     env = dict(os.environ)

--- a/tests/test_cli/test_update_harness.py
+++ b/tests/test_cli/test_update_harness.py
@@ -339,6 +339,7 @@ class TestUpdateHarnessReexec:
         assert captured["executable"] == "/usr/bin/python3"
         assert captured["argv"] == [
             "/usr/bin/python3",
+            "-I",
             "-m",
             "runops.cli.main",
             "update-harness",


### PR DESCRIPTION
### Motivation
- `update-harness` が `tools/runops` の更新後に `python -m runops.cli.main` で再実行していたため、カレントディレクトリに置かれた悪意ある `runops/` パッケージによるモジュールシャドーイング経由で任意コード実行のリスクが発生していたため対策する。 

### Description
- 再実行の呼び出しを `python -m runops.cli.main` から `python -I -m runops.cli.main` に変更して、Python の isolated モードを有効にしカレントディレクトリがインポート経路に追加されるのを防止した。 
- `--skip-pull` を付与する位置判定を新しい `argv` インデックスに合わせて調整した。 
- 再実行挙動を検証するテストの期待値を `tests/test_cli/test_update_harness.py` にて更新し、新しい `-I` フラグを含むことを検証するようにした。 

### Testing
- 実行したテスト: `uv run pytest tests/test_cli/test_update_harness.py -q` が成功し `23 passed` で全テストがパスした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea65ed1df88331b2028d85582c4e39)