### PR TITLE
fix: reject newline in qos for job script generation

### DIFF
--- a/src/runops/jobgen/generator.py
+++ b/src/runops/jobgen/generator.py
@@ -181,6 +181,10 @@ def _validate_job_config(job_config: dict[str, Any]) -> None:
     if missing:
         raise JobScriptError(f"Missing required job config keys: {', '.join(missing)}")
 
+    qos = job_config.get("qos")
+    if isinstance(qos, str) and any(char in qos for char in ("\n", "\r")):
+        raise JobScriptError("Invalid qos: newline characters are not allowed")
+
 
 def _render_script(
     *,

--- a/tests/test_slurm/test_jobgen.py
+++ b/tests/test_slurm/test_jobgen.py
@@ -165,6 +165,29 @@ class TestGenerateJobScript:
         content = path.read_text()
         assert "#SBATCH -p" not in content
 
+    def test_qos_directive_is_rendered(self, run_dir: Path) -> None:
+        """Valid qos is rendered as a single SBATCH directive."""
+        path = generate_job_script(
+            run_dir,
+            {"partition": "debug", "walltime": "01:00:00", "qos": "normal"},
+            "srun ./solver",
+        )
+        content = path.read_text()
+        assert "#SBATCH --qos=normal" in content
+
+    def test_qos_with_newline_raises(self, run_dir: Path) -> None:
+        """Reject qos values that could inject extra shell lines."""
+        with pytest.raises(JobScriptError, match="Invalid qos"):
+            generate_job_script(
+                run_dir,
+                {
+                    "partition": "debug",
+                    "walltime": "01:00:00",
+                    "qos": "normal\nid > /tmp/pwned",
+                },
+                "srun ./solver",
+            )
+
     def test_creates_submit_dir(
         self, tmp_path: Path, job_config: dict[str, object]
     ) -> None:


### PR DESCRIPTION
### Motivation
- `qos` 値がそのまま `#SBATCH --qos=...` に埋め込まれていたため、改行を含む悪意ある `qos` による `job.sh` へのコマンド注入が可能になっていた点を修正するため。

### Description
- `src/runops/jobgen/generator.py` の `_validate_job_config` に `qos` のバリデーションを追加し、改行文字（`\n` または `\r`）を含む場合は `JobScriptError` を送出するようにしました。 
- 既存の `#SBATCH --qos=...` 出力挙動は有効な `qos` ではそのまま維持されます。 
- 回帰テストを `tests/test_slurm/test_jobgen.py` に追加し、有効な `qos` のレンダリングと改行を含む `qos` の拒否を検証するテストを導入しました。

### Testing
- `uv run pytest tests/test_slurm/test_jobgen.py` を実行し、該当テストファイルのテストはすべて成功して `37 passed` でした。 
- `uv run ruff check src/runops/jobgen/generator.py tests/test_slurm/test_jobgen.py` を実行し、lint チェックはすべて通過しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6662e50c8331a30c0fe76236c069)