### PR TITLE
fix: prevent collect/plot from executing project summarize.py implicitly

### DIFF
--- a/src/runops/core/analysis.py
+++ b/src/runops/core/analysis.py
@@ -20,7 +20,6 @@ from runops.core.discovery import discover_runs
 from runops.core.exceptions import SimctlError
 from runops.core.manifest import ManifestData, read_manifest
 from runops.core.project import find_project_root
-from runops.core.state import RunState
 
 _FIGURE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".pdf"}
 _PLOT_KINDS = {"auto", "line", "scatter", "bar"}
@@ -958,31 +957,6 @@ def collect_survey_summaries(survey_dir: Path) -> SurveyCollectionResult:
                 else ""
             ),
         }
-
-        if not summary_path.is_file() and state == RunState.COMPLETED.value:
-            try:
-                generated = generate_run_summary(run_dir)
-            except (
-                KeyError,
-                OSError,
-                TypeError,
-                json.JSONDecodeError,
-                SimctlError,
-            ) as exc:
-                warnings.append(
-                    f"{run_id}: failed to auto-summarize during collect: {exc}"
-                )
-            else:
-                summary_path = generated.summary_path
-                row["summary_available"] = True
-                row["summary_path"] = str(summary_path.relative_to(survey_dir)).replace(
-                    "\\",
-                    "/",
-                )
-                generated_count += 1
-                warnings.extend(
-                    f"{run_id}: {warning}" for warning in generated.warnings
-                )
 
         if not summary_path.is_file():
             missing_count += 1

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -407,7 +407,9 @@ class TestCollect:
         assert "Collected 1 summaries" in result.output
         assert "1 runs missing" in result.output
 
-    def test_collect_auto_summarizes_completed_runs(self, tmp_path: Path) -> None:
+    def test_collect_does_not_auto_summarize_completed_runs(
+        self, tmp_path: Path
+    ) -> None:
         run_dir = _create_run(tmp_path, "R20260327-0001")
 
         mock_adapter = MagicMock()
@@ -417,10 +419,11 @@ class TestCollect:
         with patch("runops.core.analysis.get_adapter", return_value=mock_adapter_cls):
             result = runner.invoke(app, ["analyze", "collect", str(tmp_path)])
 
-        assert result.exit_code == 0
-        assert "Collected 1 summaries" in result.output
-        assert "Auto-summarized: 1" in result.output
-        assert (run_dir / "analysis" / "summary.json").exists()
+        assert result.exit_code == 1
+        assert "No summaries found" in result.output
+        assert "Auto-summarized" not in result.output
+        assert not (run_dir / "analysis" / "summary.json").exists()
+        mock_adapter.summarize.assert_not_called()
 
     def test_collect_flattens_nested_metrics_and_indexes_figures(
         self, tmp_path: Path

--- a/tests/test_core/test_actions.py
+++ b/tests/test_core/test_actions.py
@@ -171,7 +171,7 @@ def test_collect_survey_writes_aggregate_artifacts(tmp_path: Path) -> None:
     assert Path(result.data["report_path"]).exists()
 
 
-def test_collect_survey_auto_summarizes_completed_runs(tmp_path: Path) -> None:
+def test_collect_survey_does_not_auto_summarize_completed_runs(tmp_path: Path) -> None:
     run_dir = tmp_path / "R20260330-0001"
     _write_manifest(
         run_dir,
@@ -194,9 +194,10 @@ def test_collect_survey_auto_summarizes_completed_runs(tmp_path: Path) -> None:
     with patch("runops.core.analysis.get_adapter", return_value=mock_adapter_cls):
         result = collect_survey(tmp_path)
 
-    assert result.status is ActionStatus.SUCCESS
-    assert result.data["generated_summaries"] == 1
-    assert (run_dir / "analysis" / "summary.json").exists()
+    assert result.status is ActionStatus.ERROR
+    assert "No summaries found" in result.message
+    assert not (run_dir / "analysis" / "summary.json").exists()
+    mock_adapter.summarize.assert_not_called()
 
 
 def test_summarize_run_writes_summary_json(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- `collect`/`plot` previously auto-called `generate_run_summary` for completed runs missing `analysis/summary.json`, which loaded and executed project `summarize.py` and allowed arbitrary code execution from untrusted project content.
- The change restores the previous read-only behaviour for survey collection and plotting so those commands do not implicitly run project code.

### Description

- Removed the implicit call to `generate_run_summary` from `collect_survey_summaries`, so `analyze collect` / `analyze plot` will no longer execute project `summarize.py` when `analysis/summary.json` is absent (`src/runops/core/analysis.py`).
- Kept explicit summarization via the `analyze summarize` command unchanged so users can still generate summaries when they intentionally invoke it.
- Updated CLI and core action tests to assert that completed runs without `summary.json` are treated as missing and are not auto-summarized (`tests/test_cli/test_analyze.py`, `tests/test_core/test_actions.py`).

### Testing

- Ran linting with `uv run ruff check src/runops/core/analysis.py tests/test_cli/test_analyze.py tests/test_core/test_actions.py` and it passed.
- Ran targeted pytest invocations `uv run pytest tests/test_core/test_actions.py::test_collect_survey_does_not_auto_summarize_completed_runs tests/test_cli/test_analyze.py::TestCollect::test_collect_does_not_auto_summarize_completed_runs` and the tests passed.
- Ran a small test matrix including `test_collect_success` and `test_collect_partial_summaries` together with the above tests and all selected tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea694a8bd883318ed33c8dff5128bd)