### PR TITLE
fix: constrain knowledge source mounts to project root

### DIFF
--- a/src/runops/cli/knowledge/command.py
+++ b/src/runops/cli/knowledge/command.py
@@ -805,10 +805,24 @@ def detach(
     config = load_knowledge_config(root)
     mount_path: Path | None = None
     if config:
+        resolved_root = root.resolve()
         for src in config.sources:
-            if src.name == name:
-                mount_path = root / src.mount
+            if src.name != name or not src.mount:
+                continue
+            candidate = root / src.mount
+            try:
+                resolved_mount = candidate.resolve()
+                resolved_mount.relative_to(resolved_root)
+            except ValueError:
+                typer.echo(
+                    "Warning: refusing to remove mount outside project root: "
+                    f"{src.mount}",
+                    err=True,
+                )
+                mount_path = None
                 break
+            mount_path = resolved_mount
+            break
 
     try:
         removed = remove_knowledge_source(root, name)

--- a/src/runops/core/knowledge_source.py
+++ b/src/runops/core/knowledge_source.py
@@ -161,7 +161,26 @@ def _resolve_path_source(project_root: Path, raw_path: str) -> Path:
 def _mount_path(project_root: Path, source: KnowledgeSource) -> Path | None:
     if not source.mount:
         return None
-    return project_root / source.mount
+    mount = Path(source.mount)
+    if mount.is_absolute():
+        msg = (
+            f"Knowledge source '{source.name}' mount path must be relative: "
+            f"{source.mount}"
+        )
+        raise KnowledgeSourceError(msg)
+
+    resolved_root = project_root.resolve()
+    resolved_mount = (project_root / mount).resolve()
+    try:
+        resolved_mount.relative_to(resolved_root)
+    except ValueError as exc:
+        msg = (
+            f"Knowledge source '{source.name}' mount path escapes project root: "
+            f"{source.mount}"
+        )
+        raise KnowledgeSourceError(msg) from exc
+
+    return resolved_mount
 
 
 def _source_root(project_root: Path, source: KnowledgeSource) -> Path:

--- a/tests/test_cli/test_knowledge.py
+++ b/tests/test_cli/test_knowledge.py
@@ -492,6 +492,32 @@ def test_detach_not_found(tmp_path: Path) -> None:
     assert "Source not found" in result.output
 
 
+def test_detach_refuses_to_remove_path_outside_project(tmp_path: Path) -> None:
+    outside_dir = tmp_path.parent / "outside-kb"
+    outside_dir.mkdir()
+    (outside_dir / "data.txt").write_text("keep", encoding="utf-8")
+    toml = f"""
+[knowledge]
+enabled = true
+
+[[knowledge.sources]]
+name = "test-kb"
+type = "path"
+kind = "profiles"
+path = "/some/path"
+mount = "{outside_dir}"
+"""
+    project_root = _create_project(tmp_path, toml)
+
+    with patch("runops.cli.knowledge.Path.cwd", return_value=project_root):
+        result = runner.invoke(app, ["knowledge", "source", "detach", "test-kb"])
+
+    assert result.exit_code == 0
+    assert "Detached: test-kb" in result.output
+    assert "refusing to remove mount outside project root" in result.output
+    assert outside_dir.exists()
+
+
 def test_render_generates_imports(tmp_path: Path) -> None:
     toml = """
 [knowledge]

--- a/tests/test_core/test_knowledge_source.py
+++ b/tests/test_core/test_knowledge_source.py
@@ -325,6 +325,25 @@ def test_sync_source_path_not_found(tmp_path: Path) -> None:
         sync_source(project, source)
 
 
+def test_sync_source_rejects_mount_path_outside_project(tmp_path: Path) -> None:
+    from runops.core.exceptions import KnowledgeSourceError
+
+    kb_dir = _create_knowledge_source(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    source = KnowledgeSource(
+        name="test-kb",
+        source_type="path",
+        url=str(kb_dir),
+        kind="profiles",
+        mount="../outside",
+    )
+
+    with pytest.raises(KnowledgeSourceError, match="escapes project root"):
+        sync_source(project, source)
+
+
 def test_sync_source_git_clone(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()


### PR DESCRIPTION
### Motivation
- `knowledge source` の `mount` パスが検証されずに `sync` や `detach` で利用されていたため、`mount` に絶対パスや `..` を指定されるとプロジェクト外のパスを上書き/削除できる脆弱性があった。 
- 最小限の変更で外部ファイル削除やパス脱出を防ぎ、安全に `sync`/`detach` を行えるようにする。

### Description
- `src/runops/core/knowledge_source.py` の ` _mount_path` を強化し、`mount` が絶対パスでないことを拒否し、解決後に `project_root` のサブパスであることを検証するようにした（エラー時は `KnowledgeSourceError` を送出）。
- `src/runops/cli/knowledge/command.py` の `detach` コマンドで、削除前に `mount` の解決済みパスが `project_root` 配下であることを確認し、プロジェクト外であれば削除を拒否して警告を出すようにした（設定エントリの削除自体は継続するが危険な `rmtree` は実行しない）。
- 回帰テストを追加して、`../outside` のような traversal 指定が `sync_source` で拒否されることと、`detach` がプロジェクト外ディレクトリを削除しないことを確認するテストを追加した（`tests/test_core/test_knowledge_source.py` と `tests/test_cli/test_knowledge.py` を更新）。

### Testing
- `uv run ruff check src/runops/core/knowledge_source.py src/runops/cli/knowledge/command.py tests/test_core/test_knowledge_source.py tests/test_cli/test_knowledge.py` を実行し、全て通過した（`All checks passed!`）。
- 対象の pytest ケース `tests/test_core/test_knowledge_source.py::test_sync_source_rejects_mount_path_outside_project` と `tests/test_cli/test_knowledge.py::test_detach_refuses_to_remove_path_outside_project` を実行し、両方とも成功した（2 passed）。
- 変更は `fix: constrain knowledge source mounts to project root` として適用済みで、上記の静的チェックとユニットテストにより脆弱性が修正されていることを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea693861f88331b70ff8f38de664c2)