### PR TITLE
fix: prevent tool module shadowing in refactor quality gate

### DIFF
--- a/src/runops/templates/skills/python-package-refactor/scripts/refactor_quality_gate.py
+++ b/src/runops/templates/skills/python-package-refactor/scripts/refactor_quality_gate.py
@@ -11,6 +11,7 @@ import argparse
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -53,6 +54,7 @@ class Gate:
     default_run: bool = True
     heavy: bool = False
     requires_module: str | None = None
+    requires_executable: str | None = None
     timeout_seconds: float | None = None
 
 
@@ -208,9 +210,9 @@ def detect_gates(root: Path) -> list[Gate]:
         gates.append(
             Gate(
                 name="ruff-check",
-                command=[sys.executable, "-m", "ruff", "check", "."],
+                command=["ruff", "check", "."],
                 reason="Run configured Ruff lint checks.",
-                requires_module="ruff",
+                requires_executable="ruff",
                 timeout_seconds=180,
             )
         )
@@ -220,9 +222,9 @@ def detect_gates(root: Path) -> list[Gate]:
         gates.append(
             Gate(
                 name="mypy",
-                command=[sys.executable, "-m", "mypy", *targets],
+                command=["mypy", *targets],
                 reason="Run configured mypy type checks on discovered top-level modules.",
-                requires_module="mypy",
+                requires_executable="mypy",
                 timeout_seconds=300,
             )
         )
@@ -231,9 +233,9 @@ def detect_gates(root: Path) -> list[Gate]:
         gates.append(
             Gate(
                 name="pyright",
-                command=[sys.executable, "-m", "pyright"],
+                command=["pyright"],
                 reason="Run configured pyright checks if the Python pyright wrapper is installed.",
-                requires_module="pyright",
+                requires_executable="pyright",
                 timeout_seconds=300,
             )
         )
@@ -313,6 +315,13 @@ def render_plan(gates: list[Gate], include_heavy: bool = False) -> str:
 
 
 def run_gate(root: Path, gate: Gate, timeout_override: float | None = None) -> dict[str, Any]:
+    if gate.requires_executable and shutil.which(gate.requires_executable) is None:
+        return {
+            "name": gate.name,
+            "status": "skipped",
+            "reason": f"Executable '{gate.requires_executable}' is not available in PATH.",
+            "command": command_text(gate.command),
+        }
     if gate.requires_module and not module_available(gate.requires_module):
         return {
             "name": gate.name,
@@ -323,16 +332,9 @@ def run_gate(root: Path, gate: Gate, timeout_override: float | None = None) -> d
     timeout = timeout_override if timeout_override is not None else gate.timeout_seconds
     started = time.monotonic()
     try:
-        env = os.environ.copy()
-        pythonpath_items = [str(root / "src"), str(root)]
-        existing = env.get("PYTHONPATH")
-        if existing:
-            pythonpath_items.append(existing)
-        env["PYTHONPATH"] = os.pathsep.join(pythonpath_items)
         proc = subprocess.run(
             gate.command,
             cwd=str(root),
-            env=env,
             text=True,
             capture_output=True,
             timeout=timeout,


### PR DESCRIPTION
### Motivation
- リポジトリ内の悪意ある Python ファイル（例: `ruff.py`）が `python -m <tool>` 実行時にツールをシャドウして任意コードを実行できるため、品質ゲート実行時のモジュール解決経路を安全化する必要がありました。 

### Description
- `Gate` に `requires_executable` フィールドを追加しました。 
- `ruff` / `mypy` / `pyright` のゲートを `python -m ...` から直接実行バイナリ呼び出し（`[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4401b8048331976bb72eacd54228)