### PR TITLE
fix: prevent repository module shadowing in refactor quality gate

### DIFF
--- a/src/runops/templates/skills/python-package-refactor/scripts/refactor_quality_gate.py
+++ b/src/runops/templates/skills/python-package-refactor/scripts/refactor_quality_gate.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import os
+import shutil
 import subprocess
 import sys
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +53,7 @@ class Gate:
     default_run: bool = True
     heavy: bool = False
     requires_module: str | None = None
+    requires_executable: str | None = None
     timeout_seconds: float | None = None
 
 
@@ -208,9 +209,9 @@ def detect_gates(root: Path) -> list[Gate]:
         gates.append(
             Gate(
                 name="ruff-check",
-                command=[sys.executable, "-m", "ruff", "check", "."],
+                command=["ruff", "check", "."],
                 reason="Run configured Ruff lint checks.",
-                requires_module="ruff",
+                requires_executable="ruff",
                 timeout_seconds=180,
             )
         )
@@ -220,9 +221,9 @@ def detect_gates(root: Path) -> list[Gate]:
         gates.append(
             Gate(
                 name="mypy",
-                command=[sys.executable, "-m", "mypy", *targets],
+                command=["mypy", *targets],
                 reason="Run configured mypy type checks on discovered top-level modules.",
-                requires_module="mypy",
+                requires_executable="mypy",
                 timeout_seconds=300,
             )
         )
@@ -231,9 +232,9 @@ def detect_gates(root: Path) -> list[Gate]:
         gates.append(
             Gate(
                 name="pyright",
-                command=[sys.executable, "-m", "pyright"],
+                command=["pyright"],
                 reason="Run configured pyright checks if the Python pyright wrapper is installed.",
-                requires_module="pyright",
+                requires_executable="pyright",
                 timeout_seconds=300,
             )
         )
@@ -313,6 +314,13 @@ def render_plan(gates: list[Gate], include_heavy: bool = False) -> str:
 
 
 def run_gate(root: Path, gate: Gate, timeout_override: float | None = None) -> dict[str, Any]:
+    if gate.requires_executable and shutil.which(gate.requires_executable) is None:
+        return {
+            "name": gate.name,
+            "status": "skipped",
+            "reason": f"Executable '{gate.requires_executable}' is not available in PATH.",
+            "command": command_text(gate.command),
+        }
     if gate.requires_module and not module_available(gate.requires_module):
         return {
             "name": gate.name,
@@ -323,16 +331,9 @@ def run_gate(root: Path, gate: Gate, timeout_override: float | None = None) -> d
     timeout = timeout_override if timeout_override is not None else gate.timeout_seconds
     started = time.monotonic()
     try:
-        env = os.environ.copy()
-        pythonpath_items = [str(root / "src"), str(root)]
-        existing = env.get("PYTHONPATH")
-        if existing:
-            pythonpath_items.append(existing)
-        env["PYTHONPATH"] = os.pathsep.join(pythonpath_items)
         proc = subprocess.run(
             gate.command,
             cwd=str(root),
-            env=env,
             text=True,
             capture_output=True,
             timeout=timeout,


### PR DESCRIPTION
### Motivation
- Refactor quality gate が `python -m <tool>` を用いて外部ツールを実行し、さらに検査対象リポジトリのパスを `PYTHONPATH` に注入していたため、リポジトリ内の悪意ある `ruff.py` / `mypy.py` / `pyright.py` 等がインストール済みツールをシャドーイングして任意コードを実行できる脆弱性があったため、これを防止する。 

### Description
- `ruff` / `mypy` / `pyright` のゲートコマンドを `python -m <tool>` から実行ファイル直接呼び出し（`ruff`, `mypy`, `pyright`）へ変更し、モジュール名解決によるシャドーイングを回避した。 
- `Gate` に `requires_executable` フィールドを追加し、`run_gate()` 内で `shutil.which()` による PATH 上の実行ファイル存在チェックを行うようにした。 
- ゲート起動時に検査対象リポジトリの `<root>/src` と `<root>` を `PYTHONPATH` に注入する処理を削除し、`subprocess.run()` は `cwd` のみ指定して実行するように変更した。 

### Testing
- `python -m compileall src/runops/templates/skills/python-package-refactor/scripts/refactor_quality_gate.py` を実行してコンパイル可能であることを確認した（成功）。
- 開発中に `uv run ruff check` を利用して import / unused-import 等のスタイル問題を検出し修正している（初回実行では問題が報告され、それに基づき修正を適用した）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007dba77f08331bfbfa1f1927d2e32)