### PR TITLE
docs: adopt GitHub Flow

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: "Prepare and publish a new runops release. Bump version, sync __init__.py, draft Japanese release notes, create commit/tag/GitHub Release, and push to trigger PyPI publish."
+description: "Prepare and publish a new runops release through GitHub Flow. Bump version, sync __init__.py, draft Japanese release notes, open/merge a PR, tag main, create GitHub Release, and verify PyPI publish."
 ---
 
 # runops リリース
@@ -24,7 +24,10 @@ $release 0.3.0      # 明示的にバージョン指定
 ```
 
 引数なしで呼んだ場合は、変更内容から bump レベルを自動判定し、
-確認 → リリースまで一気通貫で実行する。
+確認 → release PR → tag → GitHub Release → publish 確認まで一気通貫で実行する。
+
+`main` への direct push は禁止。release commit も必ず release branch から PR に載せ、
+CI green 後に `main` へ merge してから tag を切る。
 
 ## 手順
 
@@ -86,32 +89,57 @@ commit message から以下を分類する:
 1. `pyproject.toml` の `version = "X.Y.Z"` — pip / PyPI が参照する正本
 2. `src/runops/__init__.py` の `__version__ = "X.Y.Z"` — ランタイム参照
 
-### 5. コミットとタグ
+### 5. release branch でコミットする
+
+`main` を最新化してから release branch を作る。既に release branch 上なら、base が
+最新 `origin/main` から分岐していることを確認する。
 
 ```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git switch -c release/vX.Y.Z
 git add pyproject.toml src/runops/__init__.py
 git commit -m "chore: bump version to X.Y.Z"
-git tag -a vX.Y.Z -m "<日本語のリリースノート要約>"
 ```
 
-`git commit` と `git tag` は**順に**実行する。並列に走らせない。
-tag が直前の commit ではなく 1 つ前を指すと publish が壊れる。
+### 6. release PR を作成し、merge する
 
-### 6. push して tag を公開する
-
-ユーザーの確認を得てから push する:
+release branch を push して PR を作成する。`main` へ直接 push しない。
 
 ```bash
-git push origin main
+git push -u origin release/vX.Y.Z
+gh pr create \
+  --base main \
+  --head release/vX.Y.Z \
+  --title "chore: release X.Y.Z" \
+  --body-file <release-notes.md>
+```
+
+PR の CI が green であることを確認してから merge する。merge 後、ローカル `main` を
+必ず fast-forward で最新化する。
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+git switch main
+git pull --ff-only origin main
+```
+
+### 7. main の release commit に tag を付けて公開する
+
+tag は merge 後の `main` の release commit に付ける。release branch 上では tag を切らない。
+tag push により `.github/workflows/publish.yml` が起動し、CI が自動で PyPI にパブリッシュする。
+
+```bash
+git tag -a vX.Y.Z -m "<日本語のリリースノート要約>"
 git push origin vX.Y.Z
 ```
 
-`v*` タグの push により `.github/workflows/publish.yml` が起動し、
-CI が自動で PyPI にパブリッシュする。
+`git pull --ff-only origin main`、`git tag -a`、`git push origin vX.Y.Z` は順に実行する。
+tag が release commit 以外を指すと publish が壊れる。
 
-`main` と tag の push も分けて順に実行する。
-
-### 7. GitHub Release を作成する
+### 8. GitHub Release を作成する
 
 tag を push したら、同じ tag に対する GitHub Release を必ず作成する。
 annotated tag に日本語のリリースノートを入れている場合は、それをそのまま使う:
@@ -134,7 +162,7 @@ gh release edit vX.Y.Z \
 古い tag の Release を後から作るときは、最新 release 扱いにならないよう必要に応じて
 `--latest=false` を付ける。最新の通常リリースだけを Latest にする。
 
-### 8. 確認
+### 9. 確認
 
 ```bash
 gh run list --workflow=publish.yml --limit 1
@@ -152,4 +180,4 @@ gh release view vX.Y.Z --json tagName,name,body,url
 2. bump レベルを自動判定
 3. 日本語のリリースノート草案を作る
 4. 変更サマリとバージョンをユーザーに提示して確認
-5. 確認が取れたら手順 4〜8 を順に実行 (バージョン更新 → コミット → タグ → push → GitHub Release 作成)
+5. 確認が取れたら手順 4〜9 を順に実行 (バージョン更新 → release PR → merge → tag push → GitHub Release 作成)

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -42,8 +42,10 @@ CI でも同じチェックと分岐込み coverage floor が走る。ruff forma
 
 - 1 コミット = 1 論理変更
 - commit message は英語推奨 (`fix:`, `feat:`, `refactor:`, `test:`, `docs:`)
+- GitHub Flow を採用する。作業は `codex/...`, `feature/...`, `fix/...`, `release/...` の branch で行う
+- `main` への direct push は禁止。変更は必ず PR で `main` へ入れる
+- PR merge 前に CI green を確認する
 - `--no-verify` / `--force` は使わない
-- PR は main ブランチへ
 
 ## リリース
 
@@ -52,10 +54,12 @@ CI でも同じチェックと分岐込み coverage floor が走る。ruff forma
 1. 品質ゲート通過を確認
 2. `pyproject.toml` と `src/runops/__init__.py` のバージョンを **同時に** 更新
 3. 日本語のリリースノート草案を作る
-4. `git commit -m "chore: bump version to X.Y.Z"` を作成
-5. その commit を確認してから `git tag -a vX.Y.Z` を切る
-6. `git push origin main` と `git push origin vX.Y.Z` を **順に** 実行する
-7. `CI` と `Publish to PyPI` を確認し、GitHub Release 本文も日本語で作成する
+4. `release/vX.Y.Z` branch で `git commit -m "chore: bump version to X.Y.Z"` を作成
+5. release PR を作成し、CI green 後に `main` へ merge する
+6. `main` を `git pull --ff-only origin main` で最新化し、その commit に `git tag -a vX.Y.Z` を切る
+7. `git push origin vX.Y.Z` を実行し、`Publish to PyPI` を確認する
+8. GitHub Release 本文も日本語で作成する
 
-`git commit` と `git tag`, `git push origin main` と `git push origin vX.Y.Z` は
-並列化しない。tag が 1 つ前の commit を指すと publish が壊れる。
+release branch 上で tag を切らない。PR merge 後の `main` の release commit に tag を付ける。
+`git pull --ff-only origin main`、`git tag -a`、`git push origin vX.Y.Z` は並列化しない。
+tag が release commit 以外を指すと publish が壊れる。

--- a/.claude/rules/gotchas.md
+++ b/.claude/rules/gotchas.md
@@ -48,9 +48,12 @@ PyPI パッケージのバージョンがずれる。`/release` スキルを使�
 
 ## release の commit / tag 順序
 
-release では `git commit` の完了を待ってから `git tag -a` を切る。
-commit と tag を並列に走らせると、tag が 1 つ前の commit を指したまま push されることがある。
-push も `main` と tag を順に実行する。
+release commit は `release/vX.Y.Z` branch から PR に載せ、CI green 後に `main` へ merge する。
+release branch 上では tag を切らない。merge 後に `main` を `git pull --ff-only origin main`
+で最新化し、その release commit に `git tag -a` を切る。
+
+tag 作成と `git push origin vX.Y.Z` を並列に走らせると、tag が古い commit を指したまま
+publish されることがある。
 
 ## read_text() の encoding
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: "Prepare and publish a new runops release. Bump version, sync __init__.py, draft Japanese release notes, create commit/tag/GitHub Release, and push to trigger PyPI publish."
+description: "Prepare and publish a new runops release through GitHub Flow. Bump version, sync __init__.py, draft Japanese release notes, open/merge a PR, tag main, create GitHub Release, and verify PyPI publish."
 ---
 
 # runops リリース
@@ -24,7 +24,10 @@ description: "Prepare and publish a new runops release. Bump version, sync __ini
 ```
 
 引数なしで呼んだ場合は、変更内容から bump レベルを自動判定し、
-確認 → リリースまで一気通貫で実行する。
+確認 → release PR → tag → GitHub Release → publish 確認まで一気通貫で実行する。
+
+`main` への direct push は禁止。release commit も必ず release branch から PR に載せ、
+CI green 後に `main` へ merge してから tag を切る。
 
 ## 手順
 
@@ -86,32 +89,57 @@ commit message から以下を分類する:
 1. `pyproject.toml` の `version = "X.Y.Z"` — pip / PyPI が参照する正本
 2. `src/runops/__init__.py` の `__version__ = "X.Y.Z"` — ランタイム参照
 
-### 5. コミットとタグ
+### 5. release branch でコミットする
+
+`main` を最新化してから release branch を作る。既に release branch 上なら、base が
+最新 `origin/main` から分岐していることを確認する。
 
 ```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git switch -c release/vX.Y.Z
 git add pyproject.toml src/runops/__init__.py
 git commit -m "chore: bump version to X.Y.Z"
-git tag -a vX.Y.Z -m "<日本語のリリースノート要約>"
 ```
 
-`git commit` と `git tag` は**順に**実行する。並列に走らせない。
-tag が直前の commit ではなく 1 つ前を指すと publish が壊れる。
+### 6. release PR を作成し、merge する
 
-### 6. push して tag を公開する
-
-ユーザーの確認を得てから push する:
+release branch を push して PR を作成する。`main` へ直接 push しない。
 
 ```bash
-git push origin main
+git push -u origin release/vX.Y.Z
+gh pr create \
+  --base main \
+  --head release/vX.Y.Z \
+  --title "chore: release X.Y.Z" \
+  --body-file <release-notes.md>
+```
+
+PR の CI が green であることを確認してから merge する。merge 後、ローカル `main` を
+必ず fast-forward で最新化する。
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+git switch main
+git pull --ff-only origin main
+```
+
+### 7. main の release commit に tag を付けて公開する
+
+tag は merge 後の `main` の release commit に付ける。release branch 上では tag を切らない。
+tag push により `.github/workflows/publish.yml` が起動し、CI が自動で PyPI にパブリッシュする。
+
+```bash
+git tag -a vX.Y.Z -m "<日本語のリリースノート要約>"
 git push origin vX.Y.Z
 ```
 
-`v*` タグの push により `.github/workflows/publish.yml` が起動し、
-CI が自動で PyPI にパブリッシュする。
+`git pull --ff-only origin main`、`git tag -a`、`git push origin vX.Y.Z` は順に実行する。
+tag が release commit 以外を指すと publish が壊れる。
 
-`main` と tag の push も分けて順に実行する。
-
-### 7. GitHub Release を作成する
+### 8. GitHub Release を作成する
 
 tag を push したら、同じ tag に対する GitHub Release を必ず作成する。
 annotated tag に日本語のリリースノートを入れている場合は、それをそのまま使う:
@@ -134,7 +162,7 @@ gh release edit vX.Y.Z \
 古い tag の Release を後から作るときは、最新 release 扱いにならないよう必要に応じて
 `--latest=false` を付ける。最新の通常リリースだけを Latest にする。
 
-### 8. 確認
+### 9. 確認
 
 ```bash
 gh run list --workflow=publish.yml --limit 1
@@ -152,4 +180,4 @@ gh release view vX.Y.Z --json tagName,name,body,url
 2. bump レベルを自動判定
 3. 日本語のリリースノート草案を作る
 4. 変更サマリとバージョンをユーザーに提示して確認
-5. 確認が取れたら手順 4〜8 を順に実行 (バージョン更新 → コミット → タグ → push → GitHub Release 作成)
+5. 確認が取れたら手順 4〜9 を順に実行 (バージョン更新 → release PR → merge → tag push → GitHub Release 作成)

--- a/.codex/rules/dev-workflow.md
+++ b/.codex/rules/dev-workflow.md
@@ -42,8 +42,10 @@ CI でも同じチェックと分岐込み coverage floor が走る。ruff forma
 
 - 1 コミット = 1 論理変更
 - commit message は英語推奨 (`fix:`, `feat:`, `refactor:`, `test:`, `docs:`)
+- GitHub Flow を採用する。作業は `codex/...`, `feature/...`, `fix/...`, `release/...` の branch で行う
+- `main` への direct push は禁止。変更は必ず PR で `main` へ入れる
+- PR merge 前に CI green を確認する
 - `--no-verify` / `--force` は使わない
-- PR は main ブランチへ
 
 ## リリース
 
@@ -52,10 +54,12 @@ CI でも同じチェックと分岐込み coverage floor が走る。ruff forma
 1. 品質ゲート通過を確認
 2. `pyproject.toml` と `src/runops/__init__.py` のバージョンを **同時に** 更新
 3. 日本語のリリースノート草案を作る
-4. `git commit -m "chore: bump version to X.Y.Z"` を作成
-5. その commit を確認してから `git tag -a vX.Y.Z` を切る
-6. `git push origin main` と `git push origin vX.Y.Z` を **順に** 実行する
-7. `CI` と `Publish to PyPI` を確認し、GitHub Release 本文も日本語で作成する
+4. `release/vX.Y.Z` branch で `git commit -m "chore: bump version to X.Y.Z"` を作成
+5. release PR を作成し、CI green 後に `main` へ merge する
+6. `main` を `git pull --ff-only origin main` で最新化し、その commit に `git tag -a vX.Y.Z` を切る
+7. `git push origin vX.Y.Z` を実行し、`Publish to PyPI` を確認する
+8. GitHub Release 本文も日本語で作成する
 
-`git commit` と `git tag`, `git push origin main` と `git push origin vX.Y.Z` は
-並列化しない。tag が 1 つ前の commit を指すと publish が壊れる。
+release branch 上で tag を切らない。PR merge 後の `main` の release commit に tag を付ける。
+`git pull --ff-only origin main`、`git tag -a`、`git push origin vX.Y.Z` は並列化しない。
+tag が release commit 以外を指すと publish が壊れる。

--- a/.codex/rules/gotchas.md
+++ b/.codex/rules/gotchas.md
@@ -51,9 +51,12 @@ PyPI パッケージのバージョンがずれる。`$release` スキルを使�
 
 ## release の commit / tag 順序
 
-release では `git commit` の完了を待ってから `git tag -a` を切る。
-commit と tag を並列に走らせると、tag が 1 つ前の commit を指したまま push されることがある。
-push も `main` と tag を順に実行する。
+release commit は `release/vX.Y.Z` branch から PR に載せ、CI green 後に `main` へ merge する。
+release branch 上では tag を切らない。merge 後に `main` を `git pull --ff-only origin main`
+で最新化し、その release commit に `git tag -a` を切る。
+
+tag 作成と `git push origin vX.Y.Z` を並列に走らせると、tag が古い commit を指したまま
+publish されることがある。
 
 ## read_text() の encoding
 

--- a/.codex/rules/runops.rules
+++ b/.codex/rules/runops.rules
@@ -140,6 +140,15 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["git", "push", "origin", "main"],
+    decision = "forbidden",
+    justification = "main is protected by GitHub Flow; open a pull request instead of direct-pushing.",
+    match = [
+        "git push origin main",
+    ],
+)
+
+prefix_rule(
     pattern = ["git", "push", "--force"],
     decision = "forbidden",
     justification = "Force-pushing rewrites shared history.",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,9 +283,11 @@ runops/
 
 - run の大容量出力 (work/outputs/, work/restart/, work/tmp/) は .gitignore で除外
 - テスト fixtures の TOML ファイルは Git 管理対象
+- GitHub Flow を採用する。`main` への direct push は禁止し、変更は branch + PR で入れる
+- PR merge 前に CI green を確認する。`--force` / `--no-verify` は使わない
 - `gh release create` などで release を切るときは、先に `pyproject.toml` の `[project].version` を更新し、Git tag / release 名と同じバージョンに揃えること
 - release の annotated tag message と GitHub Release 本文は日本語で書く
-- release の `git commit` → `git tag -a` → `git push origin main` → `git push origin vX.Y.Z` は順に実行し、並列化しない
+- release は `release/vX.Y.Z` branch + PR で version commit を `main` に入れ、merge 後の `main` の release commit に `git tag -a` を切って `git push origin vX.Y.Z` する
 - Codex の個人用メモや一時 override は `AGENTS.override.md` に置き、Git 管理しない
 
 ## ビルド・実行

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ project-state に影響する breaking change は `docs/migrations/v0.md` に移
 - ruff format / ruff check / mypy strict / テストカバレッジ 80%+
 - docstring は Google style
 - テスト: Slurm はモック、TOML は fixtures、CLI は CliRunner
-- Git: 1 コミット = 1 論理変更、`--no-verify` / `--force` 禁止
+- Git: GitHub Flow を採用し、`main` への direct push は禁止。1 コミット = 1 論理変更、`--no-verify` / `--force` 禁止
 - release 時は `pyproject.toml` + `__init__.py` の version を同時に更新し、annotated tag / GitHub Release は日本語で書く
 
 ## Adapter 実装時の注意


### PR DESCRIPTION
## 概要
- main 直 push 禁止と GitHub Flow を開発ルールに明記
- release skill を release branch + PR + merge 後 tag の流れに更新
- Codex の command policy に git push origin main 禁止を追加

## GitHub settings
- repository ruleset \Protect main with GitHub Flow\ を作成
- PR 必須、required checks: \lint\, \	est (3.10)\, \	est (3.11)\, \	est (3.12)\, \	est (3.13)\
- deletion と non-fast-forward を禁止

## 検証
- \git diff --check\

HarnessOps feedback なし。