### PR TITLE
chore: update HarnessOps steward skill

### DIFF
--- a/.agents/skills/hops-daily-steward/SKILL.md
+++ b/.agents/skills/hops-daily-steward/SKILL.md
@@ -14,7 +14,7 @@ This skill is a compact steward / conductor, not a new workflow engine:
 - detect repo role from `.harnessops/project.toml`
 - read current HOPS state
 - route work to existing skills
-- select at most one systemic candidate
+- select lane-bounded work, with a conservative systemic cap
 - advance local work when automated gates pass
 - report actions, blockers, and human decisions
 
@@ -61,7 +61,7 @@ For scheduled automation, delegate routine intake to CLI:
 hops steward preflight --pull --json
 ```
 
-If `can_continue` is false, stop and report. This command performs pull-first safety, doctor/check-records, migrate check, overlay counts, lane trigger scaffold, subagent plan scaffold, and run ledger creation.
+If `can_continue` is false, stop and report. This command performs pull-first safety, doctor/check-records, migrate check, overlay counts, lab health/stale-memory intake, lane trigger scaffold, subagent plan scaffold, and run ledger creation.
 
 Manual fallback only when the CLI is unavailable:
 
@@ -109,8 +109,12 @@ Weekly:
 
 # Selection Rules
 
-- New systemic candidate: max 1 per run.
+- Runtime config may override these caps, but do not increase scope by default just because more items are visible.
+- New systemic candidate: max 1 per run by default. Use 3 only for an explicit backlog cleanup run, and 5 only for an explicit maintenance sweep with strong validation time budget.
+- Existing dossier metadata / guard backfills: max 3 per run by default.
+- Read-only routing, park, reject, and no-op decisions: max 5 per run by default.
 - Existing dossier notes: max 1-3 per run.
+- Each advanced item still needs its own evidence, risk, validation or guard plan, and report line. More items must not dilute the proof standard.
 - Raw Ideas are ephemeral; do not capture them directly.
 - Prefer existing issue / dossier / record over new records.
 - `park`, `reject`, `local-only`, and no-op are valid outcomes.
@@ -152,6 +156,7 @@ If local changes were made, run validation and then choose one policy from the a
 
 - `patch-only`: leave the patch in the worktree and report that the next scheduled run will stop until reviewed.
 - `commit-local`: after validation passes, create a local automation branch or commit on the authorized branch.
+- `merge-automation-branch`: after validation passes, commit to an automation branch, push only that branch, then merge it into the authorized `merge-target-branch` or `base-branch` via the repository's normal merge path.
 
 Use CLI for the mechanical ending:
 
@@ -162,7 +167,17 @@ hops steward finalize --policy commit-local --validation-passed --json
 
 If the automation prompt does not specify a policy, default to `patch-only`.
 
-Push, PR, issue, and release actions are outside `hops steward finalize`; run them only when the automation prompt explicitly authorizes them and after validation plus a final remote divergence check.
+Push, PR, merge, issue, and release actions are outside `hops steward finalize`; run them only when the automation prompt explicitly authorizes them and after validation plus a final remote divergence check.
+
+Prefer GitHub Flow: commit to an automation feature branch, open or update a PR, and merge that branch into the protected `main`/base branch when validation and required checks pass. Direct push to `main` or another protected base branch should be disabled by repository rules and treated as unavailable unless a human explicitly authorizes a different repo policy. If a specific repo uses a Git Flow style integration branch, merge to `develop` or the configured `merge-target-branch` instead.
+
+Before merging an automation branch:
+
+1. Fetch the remote.
+2. Confirm the merge target is not behind or diverged in a way that requires manual conflict resolution.
+3. Confirm validation passed on the exact commit being merged, or that required remote checks have passed when the repo enforces them.
+4. Use a PR merge, squash merge, or fast-forward merge according to repo policy.
+5. If merge is blocked by branch protection, required checks, or conflicts, leave the pushed automation branch or PR and report the blocker.
 
 # Decision Card
 
@@ -189,7 +204,7 @@ Return a concise daily report:
 - actions performed
 - validation result
 - local changes / local commit state
-- remote actions performed or skipped by policy
+- remote actions performed or skipped by policy, including pushed branch, PR, or merge target
 - blocked or parked items
 - remote actions requiring confirmation
 - run ledger: branch, start_sha, head_sha, pull_status, issue_snapshot

--- a/.claude/skills/hops-daily-steward/SKILL.md
+++ b/.claude/skills/hops-daily-steward/SKILL.md
@@ -14,7 +14,7 @@ This skill is a compact steward / conductor, not a new workflow engine:
 - detect repo role from `.harnessops/project.toml`
 - read current HOPS state
 - route work to existing skills
-- select at most one systemic candidate
+- select lane-bounded work, with a conservative systemic cap
 - advance local work when automated gates pass
 - report actions, blockers, and human decisions
 
@@ -61,7 +61,7 @@ For scheduled automation, delegate routine intake to CLI:
 hops steward preflight --pull --json
 ```
 
-If `can_continue` is false, stop and report. This command performs pull-first safety, doctor/check-records, migrate check, overlay counts, lane trigger scaffold, subagent plan scaffold, and run ledger creation.
+If `can_continue` is false, stop and report. This command performs pull-first safety, doctor/check-records, migrate check, overlay counts, lab health/stale-memory intake, lane trigger scaffold, subagent plan scaffold, and run ledger creation.
 
 Manual fallback only when the CLI is unavailable:
 
@@ -109,8 +109,12 @@ Weekly:
 
 # Selection Rules
 
-- New systemic candidate: max 1 per run.
+- Runtime config may override these caps, but do not increase scope by default just because more items are visible.
+- New systemic candidate: max 1 per run by default. Use 3 only for an explicit backlog cleanup run, and 5 only for an explicit maintenance sweep with strong validation time budget.
+- Existing dossier metadata / guard backfills: max 3 per run by default.
+- Read-only routing, park, reject, and no-op decisions: max 5 per run by default.
 - Existing dossier notes: max 1-3 per run.
+- Each advanced item still needs its own evidence, risk, validation or guard plan, and report line. More items must not dilute the proof standard.
 - Raw Ideas are ephemeral; do not capture them directly.
 - Prefer existing issue / dossier / record over new records.
 - `park`, `reject`, `local-only`, and no-op are valid outcomes.
@@ -152,6 +156,7 @@ If local changes were made, run validation and then choose one policy from the a
 
 - `patch-only`: leave the patch in the worktree and report that the next scheduled run will stop until reviewed.
 - `commit-local`: after validation passes, create a local automation branch or commit on the authorized branch.
+- `merge-automation-branch`: after validation passes, commit to an automation branch, push only that branch, then merge it into the authorized `merge-target-branch` or `base-branch` via the repository's normal merge path.
 
 Use CLI for the mechanical ending:
 
@@ -162,7 +167,17 @@ hops steward finalize --policy commit-local --validation-passed --json
 
 If the automation prompt does not specify a policy, default to `patch-only`.
 
-Push, PR, issue, and release actions are outside `hops steward finalize`; run them only when the automation prompt explicitly authorizes them and after validation plus a final remote divergence check.
+Push, PR, merge, issue, and release actions are outside `hops steward finalize`; run them only when the automation prompt explicitly authorizes them and after validation plus a final remote divergence check.
+
+Prefer GitHub Flow: commit to an automation feature branch, open or update a PR, and merge that branch into the protected `main`/base branch when validation and required checks pass. Direct push to `main` or another protected base branch should be disabled by repository rules and treated as unavailable unless a human explicitly authorizes a different repo policy. If a specific repo uses a Git Flow style integration branch, merge to `develop` or the configured `merge-target-branch` instead.
+
+Before merging an automation branch:
+
+1. Fetch the remote.
+2. Confirm the merge target is not behind or diverged in a way that requires manual conflict resolution.
+3. Confirm validation passed on the exact commit being merged, or that required remote checks have passed when the repo enforces them.
+4. Use a PR merge, squash merge, or fast-forward merge according to repo policy.
+5. If merge is blocked by branch protection, required checks, or conflicts, leave the pushed automation branch or PR and report the blocker.
 
 # Decision Card
 
@@ -189,7 +204,7 @@ Return a concise daily report:
 - actions performed
 - validation result
 - local changes / local commit state
-- remote actions performed or skipped by policy
+- remote actions performed or skipped by policy, including pushed branch, PR, or merge target
 - blocked or parked items
 - remote actions requiring confirmation
 - run ledger: branch, start_sha, head_sha, pull_status, issue_snapshot

--- a/.harnessops/lock.json
+++ b/.harnessops/lock.json
@@ -4,7 +4,7 @@
       ".agents/skills/harnessops-bridge/SKILL.md": "sha256:54fbcc3fd3b62c22564e7f4f78acdc41e3448acf3abc3733bb030e4852bce173",
       ".agents/skills/hops-add-failure/SKILL.md": "sha256:74406e5bd9a2cbf51748f5a7b40c040ba0e3fd10055cc96eb72d8185e3cefc20",
       ".agents/skills/hops-compact-lab-memory/SKILL.md": "sha256:565e0293d2512910fb3093a3b4c55fd61d987dd4f2cbe5401063ecec50397484",
-      ".agents/skills/hops-daily-steward/SKILL.md": "sha256:1db2777252e5bc85e6c1da351f8242576f42ad20fb21c2ce8c11fa4040714887",
+      ".agents/skills/hops-daily-steward/SKILL.md": "sha256:e9785f47a28be73909e33193141d15b1673e0bbb12daa9c5f0e425d2fd19ca1f",
       ".agents/skills/hops-diagnose/SKILL.md": "sha256:11ac79c919cde244af19fea7ebebf583aee9dfa1afcf1a14d68de2ecef5443e7",
       ".agents/skills/hops-export-feedback/SKILL.md": "sha256:fef12024b27ae617a5f191a2da034176934182b807ed063ad103b62ec0e3f5d4",
       ".agents/skills/hops-import-feedback/SKILL.md": "sha256:fe9a32739936fb658d10d5c5675f108a2f25e084d4c7e2c4253490f82e1b3363",
@@ -17,7 +17,7 @@
       ".claude/skills/harnessops-bridge/SKILL.md": "sha256:54fbcc3fd3b62c22564e7f4f78acdc41e3448acf3abc3733bb030e4852bce173",
       ".claude/skills/hops-add-failure/SKILL.md": "sha256:dceadfdfd5be346b7b523fb7ca8cded2413a8bc14c3edf99675a4401656e03b2",
       ".claude/skills/hops-compact-lab-memory/SKILL.md": "sha256:565e0293d2512910fb3093a3b4c55fd61d987dd4f2cbe5401063ecec50397484",
-      ".claude/skills/hops-daily-steward/SKILL.md": "sha256:1db2777252e5bc85e6c1da351f8242576f42ad20fb21c2ce8c11fa4040714887",
+      ".claude/skills/hops-daily-steward/SKILL.md": "sha256:e9785f47a28be73909e33193141d15b1673e0bbb12daa9c5f0e425d2fd19ca1f",
       ".claude/skills/hops-diagnose/SKILL.md": "sha256:11ac79c919cde244af19fea7ebebf583aee9dfa1afcf1a14d68de2ecef5443e7",
       ".claude/skills/hops-export-feedback/SKILL.md": "sha256:fb33bcc188101f55399fc213799377718f31d7ebc1d02c69cf527f87c6087eb3",
       ".claude/skills/hops-import-feedback/SKILL.md": "sha256:fe9a32739936fb658d10d5c5675f108a2f25e084d4c7e2c4253490f82e1b3363",
@@ -29,7 +29,7 @@
       ".claude/skills/hops-update-harness/SKILL.md": "sha256:ff972cb584cb420205e216e325ea6158c171617447fcaa2e0dded80e06c1e4a5"
     }
   },
-  "harnessops_version": "0.1.8",
+  "harnessops_version": "0.1.9",
   "layout_version": "0.1",
   "managed_files": {
     "harness-lab/README.md": "sha256:789a733220c9918b65f6d7afbddb13ccc2d842485cca9426bb8e5dc52c24a797",


### PR DESCRIPTION
## 概要
- HarnessOps 0.1.9 の managed artifact に更新
- daily steward skill に GitHub Flow / automation branch merge 方針を反映
- .harnessops/lock.json の managed hash と harnessops_version を更新

## 検証
- `uvx --from harnessops hops doctor --check-overlay --check-records`
- `uvx --from harnessops hops migrate --check`
- `git diff --check`

HarnessOps feedback なし。
