### PR TITLE
Sync HarnessOps lab resolution for IMP0003

### DIFF
--- a/.harnessops/lock.json
+++ b/.harnessops/lock.json
@@ -35,7 +35,7 @@
     "harness-lab/README.md": "sha256:789a733220c9918b65f6d7afbddb13ccc2d842485cca9426bb8e5dc52c24a797",
     "harness-lab/views/backlog.md": "sha256:0ed4436872ad24f9c73737b7f84290306dc4baaf36154b7e36be521e985b791c",
     "harness-lab/views/imported-feedback.md": "sha256:080f413ce98a7df46368e0c85c68ffe45f3054807b202aadddaa0783306066bc",
-    "harness-lab/views/improvements.md": "sha256:7d042e29995c3ac9713d45f42917f9c009285a9230dc1b33f37f1a0b6c47a2ad",
+    "harness-lab/views/improvements.md": "sha256:65d8b225177090e914717eae1c62fd648467b82ce88baa0986d33b7d42d31ce5",
     "harness-lab/views/research-scans.md": "sha256:6d61d712641e7eddc710614cf7bc59889c78e9532dc82666e4d82dadcc06cf7a",
     "harness-lab/views/score-trajectory.md": "sha256:a3d2f445609e5e9da0269ece3b10aff2414f3830bd185ad257d32ae19026b616"
   },

--- a/harness-lab/improvements/IMP0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md
+++ b/harness-lab/improvements/IMP0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md
@@ -2,25 +2,32 @@
 id: IMP0003
 record_type: improvement_dossier
 created_at: '2026-05-13T22:41:47+09:00'
-updated_at: '2026-05-13T22:41:50+09:00'
-status: active
-source_type: observation
+updated_at: '2026-05-14T04:13:41+09:00'
+status: adopted
+source_type: external-resolution
 scope: harnessops-core
-maturity: raw
+maturity: adopted
 relation: new
 promotion_level: target-lab-case
 source_feedback: FB0003
-eval_cases: []
-hypotheses: []
-decisions: []
+eval_cases:
+- E0003
+hypotheses:
+- H0003
+decisions:
+- D0002
 research_scans: []
 classification:
   capability: role_scoped_agent_bridge
   failure_class: project_feedback_interface_too_broad
 guard:
-  status: not-defined
-  path:
-investigation: []
+  status: implemented
+  path: harnessops-core:tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface
+investigation:
+- created_at: '2026-05-14T04:12:47+09:00'
+  kind: external-resolution
+  summary: 'HarnessOps issue #12 was closed as resolved in v0.1.8: feedback-source/local-and-feedback repos now receive a project-side interface focused on lifecycle and feedback capture/export, while lab/eval/propose/decide guidance stays in upstream/meta lab repos. Installed harnessops 0.1.9 reproduces the scoped project bridge and upstream main carries tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface.'
+  evidence_ref: https://github.com/Nkzono99/harnessops/issues/12#issuecomment-4442791945
 links:
   issue_url: https://github.com/Nkzono99/harnessops/issues/12
 ---
@@ -29,14 +36,14 @@ links:
 
 ## Status
 
-- status: active
-- maturity: raw
-- source_type: observation
+- status: adopted
+- maturity: adopted
+- source_type: external-resolution
 - scope: harnessops-core
 - relation: new
 - promotion_level: target-lab-case
 - source_feedback: `FB0003`
-- linked_records: `FB0003`
+- linked_records: `FB0003`, `E0003`, `H0003`, `D0002`
 
 ## Source Observation
 
@@ -63,7 +70,7 @@ HarnessOps should provide a project-side minimal interface or role-scoped bridge
 
 ## Investigation
 
-調査メモはまだありません。
+- 2026-05-14T04:12:47+09:00 [external-resolution] HarnessOps issue #12 was closed as resolved in v0.1.8: feedback-source/local-and-feedback repos now receive a project-side interface focused on lifecycle and feedback capture/export, while lab/eval/propose/decide guidance stays in upstream/meta lab repos. Installed harnessops 0.1.9 reproduces the scoped project bridge and upstream main carries tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface. (evidence: https://github.com/Nkzono99/harnessops/issues/12#issuecomment-4442791945)
 
 ## Research Scans
 
@@ -72,22 +79,72 @@ research scan はまだありません。
 
 ## Evaluation
 
-評価ケースはまだありません。
+### E0003: E0003: FB0003-project-side-feedback-source-repositories-need-a-role-scoped-interface を評価
+
+
+- source: `harness-lab/records/eval-cases/E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md`
+
+- capability: role_scoped_agent_bridge
+
+- failure_class: project_feedback_interface_too_broad
+
+- manual_eval_yml: `harness-lab/views/eval-results/E0003-manual-score.yml`
+- manual_eval_md: `harness-lab/views/eval-results/E0003-manual-score.md`
+- scores: impact=3, mechanism_clarity=5, evaluability=5, minimality=5, regression_risk=1, operator_burden=5, anti_theater=5, maintainability=5, privacy_sanitization_risk=5
+- notes: External fix verified: harnessops#12 is closed with v0.1.8 resolution notes, installed harnessops 0.1.9 generates a feedback-source project bridge without lab/propose/decide commands, and upstream main includes tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface.
 
 
 ## Hypotheses
 
-仮説はまだありません。
+### H0003: H0003: E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface の仮説
+
+
+Source: `harness-lab/records/hypotheses/H0003-e0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md`
+
+
+# H0003: E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface の仮説
+
+## 仮説
+
+Upstream HarnessOps role-scoped agent bridge resolves FB0003 by giving feedback-source project repositories only lifecycle and feedback capture/export guidance.
+
+## メカニズム
+
+The bridge generator selects a project-side body and feedback-source skill allowlist for feedback-source/local-and-feedback modes, while upstream/meta lab modes keep lab, eval, propose, and decide guidance.
+
+## 最小実装
+
+No runops code change is needed in this target repo; sync the local lab record to the upstream resolution and rely on harnessops v0.1.8+ update-harness for stale project bridges.
+
+## 代替案: 削除または統合
+
+Leave project repos with the generic lab bridge guidance and rely on agents to infer role boundaries from project.toml, which keeps the privacy/adoption boundary ambiguous.
+
+## 期待される利点
+
+Project repositories get a smaller, role-appropriate interface that reduces accidental harness-lab/adoption work in private feedback-source repos.
+
+## 想定される欠点
+
+Existing project repos with stale generated bridge files still need update-harness before they receive the scoped guidance.
+
+## 評価計画
+
+Verify harnessops#12 is closed, installed harnessops 0.1.9 generates a feedback-source bridge without lab/propose/decide commands, and upstream guard test test_generated_bridge_scopes_feedback_source_interface covers the behavior.
+
+## 中止基準
+
+Reopen if a feedback-source generated bridge again includes lab/eval/propose/decide guidance, or if the skill allowlist omits required feedback capture/export commands.
 
 
 ## Evidence
 
-評価結果はまだありません。
+`harness-lab/views/eval-results/E0003-manual-score.md`
 
 ## Guard
 
-- status: not-defined
-- path: None
+- status: implemented
+- path: harnessops-core:tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface
 
 ## Links
 
@@ -99,4 +156,34 @@ research scan はまだありません。
 
 ## Decision Log
 
-判断レコードはまだありません。
+### D0002: D0002: adopted H0003
+
+
+Source: `harness-lab/records/decisions/D0002-adopted-h0003.md`
+
+
+# D0002: adopted H0003
+
+## 判断
+
+adopted
+
+## 理由
+
+Upstream HarnessOps now role-scopes generated project bridges, matching FB0003's expected change.
+
+## 証拠
+
+harnessops#12 closed as resolved in v0.1.8; installed harnessops 0.1.9 project bridge omits lab/propose/decide commands; upstream guard tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface asserts the scoped behavior.
+
+## 回帰リスク
+
+Low for runops: this is local lab state sync only. Residual risk is stale generated bridge files in already initialized project repositories until update-harness is run.
+
+## フォローアップ
+
+Project repositories with stale generated HarnessOps bridge files should run uvx --refresh-package harnessops --from harnessops hops update-harness --agent-bridge.
+
+## 回帰ガード
+
+harnessops-core:tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface

--- a/harness-lab/records/decisions/D0002-adopted-h0003.md
+++ b/harness-lab/records/decisions/D0002-adopted-h0003.md
@@ -1,0 +1,36 @@
+---
+id: D0002
+record_type: decision
+created_at: '2026-05-14T04:13:32+09:00'
+status: adopted
+source: H0003
+evidence:
+  summary: harnessops#12 closed as resolved in v0.1.8; installed harnessops 0.1.9 project bridge omits lab/propose/decide commands; upstream guard tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface asserts the scoped behavior.
+  guard_path: harnessops-core:tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface
+---
+
+# D0002: adopted H0003
+
+## 判断
+
+adopted
+
+## 理由
+
+Upstream HarnessOps now role-scopes generated project bridges, matching FB0003's expected change.
+
+## 証拠
+
+harnessops#12 closed as resolved in v0.1.8; installed harnessops 0.1.9 project bridge omits lab/propose/decide commands; upstream guard tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface asserts the scoped behavior.
+
+## 回帰リスク
+
+Low for runops: this is local lab state sync only. Residual risk is stale generated bridge files in already initialized project repositories until update-harness is run.
+
+## フォローアップ
+
+Project repositories with stale generated HarnessOps bridge files should run uvx --refresh-package harnessops --from harnessops hops update-harness --agent-bridge.
+
+## 回帰ガード
+
+harnessops-core:tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface

--- a/harness-lab/records/eval-cases/E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md
+++ b/harness-lab/records/eval-cases/E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md
@@ -1,0 +1,41 @@
+---
+id: E0003
+record_type: eval_case
+created_at: '2026-05-14T04:12:57+09:00'
+status: active
+capability: role_scoped_agent_bridge
+failure_class: project_feedback_interface_too_broad
+source_feedback: FB0003
+---
+
+# E0003: FB0003-project-side-feedback-source-repositories-need-a-role-scoped-interface を評価
+
+## フィクスチャ
+
+- source_feedback: `harness-lab/records/feedback/FB0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md`
+- fixture_dir: `harness-lab/records/eval-cases/fixtures/E0003`
+- observation: runops project directories initialize HarnessOps with profile=runops-project, which is feedback-source mode and writes harness-feedback/. In that role agents mainly need feedback capture/export plus lifecycle checks, but the generic agent bridge exposes broader harness-lab/eval/propose commands that belong to target or meta repositories. This blurs the boundary between project-side private feedback capture and upstream adoption decisions.
+
+## タスク
+
+`role_scoped_agent_bridge` の `project_feedback_interface_too_broad` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
+
+In runops, runo init delegates to hops init --profile runops-project --with-agent-bridge. The runops-project profile is mode=feedback-source with path=harness-feedback, while the generated HarnessOps bridge lists lab capture/dossier/investigate/classify/new-eval-case/propose/eval/decide commands as general guidance.
+
+## 期待される挙動
+
+HarnessOps should provide a project-side minimal interface or role-scoped bridge for feedback-source repositories, exposing init/doctor/update-harness/migrate and feedback commands while keeping lab/eval/propose/decide guidance scoped to upstream-lab or meta-lab repositories.
+
+## 合格基準
+
+- `project_feedback_interface_too_broad` の再現条件が検出または防止される。
+- 提案または実装される変更が source feedback の期待変更に対応している。
+- `hops eval --case E0003 --manual` の score と notes で採用判断に必要な証拠を説明できる。
+- 非公開プロジェクト詳細を追加で要求しない。
+
+## 不合格基準
+
+- `project_feedback_interface_too_broad` の再現条件を見逃す。
+- source feedback の期待変更と無関係な改善案になる。
+- 評価が yml score へ記録されず、採用判断の証拠として追えない。
+- 再現または判断に非公開文脈が必要になる。

--- a/harness-lab/records/hypotheses/H0003-e0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md
+++ b/harness-lab/records/hypotheses/H0003-e0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md
@@ -1,0 +1,42 @@
+---
+id: H0003
+record_type: hypothesis
+created_at: '2026-05-14T04:13:14+09:00'
+status: proposed
+target_capability: role_scoped_agent_bridge
+source_eval_case: E0003
+---
+
+# H0003: E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface の仮説
+
+## 仮説
+
+Upstream HarnessOps role-scoped agent bridge resolves FB0003 by giving feedback-source project repositories only lifecycle and feedback capture/export guidance.
+
+## メカニズム
+
+The bridge generator selects a project-side body and feedback-source skill allowlist for feedback-source/local-and-feedback modes, while upstream/meta lab modes keep lab, eval, propose, and decide guidance.
+
+## 最小実装
+
+No runops code change is needed in this target repo; sync the local lab record to the upstream resolution and rely on harnessops v0.1.8+ update-harness for stale project bridges.
+
+## 代替案: 削除または統合
+
+Leave project repos with the generic lab bridge guidance and rely on agents to infer role boundaries from project.toml, which keeps the privacy/adoption boundary ambiguous.
+
+## 期待される利点
+
+Project repositories get a smaller, role-appropriate interface that reduces accidental harness-lab/adoption work in private feedback-source repos.
+
+## 想定される欠点
+
+Existing project repos with stale generated bridge files still need update-harness before they receive the scoped guidance.
+
+## 評価計画
+
+Verify harnessops#12 is closed, installed harnessops 0.1.9 generates a feedback-source bridge without lab/propose/decide commands, and upstream guard test test_generated_bridge_scopes_feedback_source_interface covers the behavior.
+
+## 中止基準
+
+Reopen if a feedback-source generated bridge again includes lab/eval/propose/decide guidance, or if the skill allowlist omits required feedback capture/export commands.

--- a/harness-lab/views/eval-results/E0003-manual-score.md
+++ b/harness-lab/views/eval-results/E0003-manual-score.md
@@ -1,0 +1,26 @@
+<!-- harnessops により生成; source records が正本 -->
+# 手動評価結果: E0003
+
+送信元: `harness-lab/records/eval-cases/E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md`
+
+## スコア
+
+- impact: 3
+- mechanism_clarity: 5
+- evaluability: 5
+- minimality: 5
+- regression_risk: 1
+- operator_burden: 5
+- anti_theater: 5
+- maintainability: 5
+- privacy_sanitization_risk: 5
+
+## メモ
+
+External fix verified: harnessops#12 is closed with v0.1.8 resolution notes, installed harnessops 0.1.9 generates a feedback-source project bridge without lab/propose/decide commands, and upstream main includes tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface.
+
+## 評価ケース
+
+- capability: role_scoped_agent_bridge
+- failure_class: project_feedback_interface_too_broad
+- source_feedback: FB0003

--- a/harness-lab/views/eval-results/E0003-manual-score.yml
+++ b/harness-lab/views/eval-results/E0003-manual-score.yml
@@ -1,0 +1,17 @@
+schema_version: '0.1'
+record_type: manual_eval_result
+created_at: '2026-05-14T04:13:22+09:00'
+eval_case: E0003
+experiment:
+scores:
+  impact: 3
+  mechanism_clarity: 5
+  evaluability: 5
+  minimality: 5
+  regression_risk: 1
+  operator_burden: 5
+  anti_theater: 5
+  maintainability: 5
+  privacy_sanitization_risk: 5
+notes: 'External fix verified: harnessops#12 is closed with v0.1.8 resolution notes, installed harnessops 0.1.9 generates a feedback-source project bridge without lab/propose/decide commands, and upstream main includes tests/test_agent_harness_contract.py::test_generated_bridge_scopes_feedback_source_interface.'
+source_record: harness-lab/records/eval-cases/E0003-fb0003-project-side-feedback-source-repositories-need-a-role-scoped-interface.md

--- a/harness-lab/views/improvements.md
+++ b/harness-lab/views/improvements.md
@@ -3,4 +3,4 @@
 
 - `IMP0001` active maturity=investigated scope=harnessops-core promotion=target-lab-case source=FB0001 harness_improvement_capture missing_proactive_harness_lab_capture
 - `IMP0002` needs-more-evidence maturity=investigated scope=harnessops-core promotion=core-bugfix source=FB0002 lab_cli_error_handling expected_user_error_traceback
-- `IMP0003` active maturity=raw scope=harnessops-core promotion=target-lab-case source=FB0003 role_scoped_agent_bridge project_feedback_interface_too_broad
+- `IMP0003` adopted maturity=adopted scope=harnessops-core promotion=target-lab-case source=FB0003 role_scoped_agent_bridge project_feedback_interface_too_broad


### PR DESCRIPTION
## Summary
- Mark IMP0003 / FB0003 as adopted after upstream HarnessOps resolved role-scoped feedback-source bridges.
- Add E0003, H0003, D0002, manual score, and implemented guard reference.
- Refresh generated improvements view and HOPS lock hash.

## Validation
- `uv run pytest` (1096 passed, 3 skipped)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uvx --from harnessops hops doctor --check-overlay --check-records`
- `uvx --from harnessops hops migrate --check`