### PR TITLE
[codex] Add paper-facing MCP inspection tools

### DIFF
--- a/docs/layers/research.md
+++ b/docs/layers/research.md
@@ -25,6 +25,7 @@ decision ledger です。
 research/
   README.md
   agenda.md
+  paper_requests.toml
   proposals/
     .gitkeep
   reviews/
@@ -33,6 +34,18 @@ research/
 
 `runo init` はこの構成を作ります。既存 project では `runo update-harness` が、
 不足している `research/` scaffold だけを補完します。
+
+## paper request contract
+
+paper draft から出た追加解析・図表・追加実験・export 要望は
+`research/paper_requests.toml` に structured queue として置けます。これは
+実行キューではなく、paper 側の文脈を `research/agenda.md` や
+`research/proposals/` へ戻すための handoff です。
+
+詳細な schema と例は [Paper Request Contract](../paper-requests.md) を参照します。
+MCP では `runops.paper.requests.list` と `runops.paper.request.plan` が read / plan
+入口を提供します。追加実験の run creation / survey expansion / submit は明示操作に
+残します。
 
 ## context 入口
 
@@ -52,6 +65,7 @@ research/
 | `notes/YYYY-MM-DD.md` | 日次 lab notebook | append-only |
 | `notes/reports/` | 整理済み long-form report | 改稿可 |
 | `research/agenda.md` | 現在の研究判断 | mutable |
+| `research/paper_requests.toml` | paper draft から戻る解析・図表・実験要望 | structured queue |
 | `research/proposals/` | 実行前の重い判断 | 必要時に新規作成 |
 | `research/reviews/` | 過去判断の snapshot | checkpoint ごとに新規作成 |
 | `.agents/skills/`, `.claude/skills/` | Agent の手順 | harness template から生成 |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -116,6 +116,31 @@ error / blocked も JSON-RPC protocol error ではなく、通常の tool result
 `runops.slurm.queue(live=true)` と `runops.slurm.job.inspect` は Slurm command を読むため、
 Slurm が PATH にない環境では blocked envelope を返すことがある。
 
+### analysis / publication tools
+
+| Tool | Safety | 内容 |
+|------|--------|------|
+| `runops.analysis.artifacts` | inspect | run の `analysis/artifacts.toml` または survey の `summary/artifacts.toml` を読む |
+| `runops.survey.summary` | inspect | 既存 `summary/survey_summary.json` の counts / stats / readiness を読む |
+| `runops.analysis.plot_columns` | inspect | 既存 `survey_summary.json` から plot 可能な列を返す |
+| `runops.publication.exports.list` | read | `exports/papers/` 配下の publication export manifest を列挙する |
+| `runops.publication.export.inspect` | inspect | 1 つの publication export `manifest.json` と files/source metadata を読む |
+
+これらは read / inspect 専用で、`runo analyze collect`, `plot`, `export` のような
+成果物生成は行わない。missing / 壊れた artifact index や manifest は MCP protocol
+error ではなく、warning / error を含む envelope として返す。
+
+### paper request tools
+
+| Tool | Safety | 内容 |
+|------|--------|------|
+| `runops.paper.requests.list` | read | `research/paper_requests.toml` の paper-facing request を列挙する |
+| `runops.paper.request.plan` | plan | 1 件の request を `research/agenda.md` / `research/proposals/` へ戻す plan を返す |
+
+paper request は paper draft から runops project に戻る追加解析・図表・追加実験・export
+要望の contract であり、実行キューではない。`experiment_request` も MCP 経由では
+submit せず、case / survey design と human gate を含む plan に留める。
+
 ## Submit Planning
 
 `runops.job.plan_submit` は `runo runs submit --dry-run` 相当の structured plan を返す。
@@ -163,6 +188,13 @@ enabled_tools = [
   "runops.project.status",
   "runops.project.inspect",
   "runops.project.doctor",
+  "runops.publication.exports.list",
+  "runops.publication.export.inspect",
+  "runops.analysis.artifacts",
+  "runops.survey.summary",
+  "runops.analysis.plot_columns",
+  "runops.paper.requests.list",
+  "runops.paper.request.plan",
   "runops.run.list",
   "runops.run.inspect",
   "runops.run.logs",

--- a/docs/paper-requests.md
+++ b/docs/paper-requests.md
@@ -1,0 +1,47 @@
+# Paper Request Contract
+
+paper draft から runops project へ戻す追加解析・図表・追加実験の要望は、
+`research/paper_requests.toml` に structured queue として置く。
+これは実行キューではなく、`research/agenda.md` や `research/proposals/` へ
+判断を戻すための handoff である。
+
+## File
+
+```toml
+#:schema https://runops.dev/schemas/paper_requests.json
+schema_version = 1
+
+[[requests]]
+id = "PAPER-REQ-0001"
+type = "analysis_request"
+title = "Add sheath width comparison for Figure 2"
+paper_id = "draft-a"
+paper_context = "Results / Figure 2"
+desired_artifact = "table or figure comparing sheath width across angle_scan"
+source_link = "refs/links.toml#paper.draft-a"
+related_runs = ["R20260412-0003"]
+related_surveys = ["runs/sheath/angle_scan"]
+priority = "medium"
+status = "open"
+human_gate = true
+```
+
+`type` は `analysis_request`, `figure_request`, `experiment_request`,
+`evidence_gap`, `export_request` のいずれかにする。
+
+## Routing
+
+- 軽い解析・図表・export 要望は `research/agenda.md` の current decision /
+  next action に要約して追う。
+- 高コスト rerun、新しい survey、paper-level claim に関わる要望は
+  `research/proposals/` に proposal を作ってから進める。
+- `experiment_request` は case / survey design までを計画し、MCP 経由で勝手に
+  submit しない。
+
+## MCP
+
+- `runops.paper.requests.list` は request queue を read-only に列挙する。
+- `runops.paper.request.plan` は 1 件の request を agenda / proposal へ戻す
+  plan を返す。file mutation、run creation、job submit は行わない。
+- 図表候補や export 候補の確認は `runops.analysis.artifacts`,
+  `runops.survey.summary`, `runops.publication.exports.list` を使う。

--- a/docs/toml-reference.md
+++ b/docs/toml-reference.md
@@ -952,6 +952,38 @@ runo analyze export R20260412-0003 --paper draft-a --paper-status placeholder
 runo analyze export runs/sheath/angle_scan --paper draft-a --mode symlink
 ```
 
+## research/paper_requests.toml
+
+paper draft から runops project へ戻す追加解析・図表・追加実験・export 要望の
+structured queue。schema は `schemas/paper_requests.json`。
+これは実行キューではなく、`research/agenda.md` や `research/proposals/` へ
+判断を戻すための handoff である。
+
+```toml
+#:schema https://runops.dev/schemas/paper_requests.json
+schema_version = 1
+
+[[requests]]
+id = "PAPER-REQ-0001"
+type = "analysis_request"
+title = "Add sheath width comparison for Figure 2"
+paper_id = "draft-a"
+paper_context = "Results / Figure 2"
+desired_artifact = "table or figure comparing sheath width across angle_scan"
+source_link = "refs/links.toml#paper.draft-a"
+related_runs = ["R20260412-0003"]
+related_surveys = ["runs/sheath/angle_scan"]
+priority = "medium"
+status = "open"
+human_gate = true
+```
+
+`type` は `analysis_request`, `figure_request`, `experiment_request`,
+`evidence_gap`, `export_request` のいずれか。
+`priority` は `low | medium | high | urgent`、`status` は
+`open | planned | in_progress | blocked | done | rejected`。
+追加実験の実行は明示操作に残し、MCP 経由で自動 submit しない。
+
 ---
 
 ## JSON Schema

--- a/harness-lab/views/eval-results/E0004-manual-score.md
+++ b/harness-lab/views/eval-results/E0004-manual-score.md
@@ -1,0 +1,26 @@
+<!-- harnessops により生成; source records が正本 -->
+# 手動評価結果: E0004
+
+送信元: `harness-lab/records/eval-cases/E0004-fb0004-mcp-publication-export-manifest-inspect.md`
+
+## スコア
+
+- impact: 4
+- mechanism_clarity: 5
+- evaluability: 5
+- minimality: 4
+- regression_risk: 2
+- operator_burden: 4
+- anti_theater: 5
+- maintainability: 4
+- privacy_sanitization_risk: 5
+
+## メモ
+
+Implemented read-only MCP publication export tools: runops.publication.exports.list and runops.publication.export.inspect. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.
+
+## 評価ケース
+
+- capability: unclassified
+- failure_class: unclassified
+- source_feedback: FB0004

--- a/harness-lab/views/eval-results/E0004-manual-score.yml
+++ b/harness-lab/views/eval-results/E0004-manual-score.yml
@@ -1,0 +1,17 @@
+schema_version: '0.1'
+record_type: manual_eval_result
+created_at: '2026-05-14T11:43:44+09:00'
+eval_case: E0004
+experiment:
+scores:
+  impact: 4
+  mechanism_clarity: 5
+  evaluability: 5
+  minimality: 4
+  regression_risk: 2
+  operator_burden: 4
+  anti_theater: 5
+  maintainability: 4
+  privacy_sanitization_risk: 5
+notes: 'Implemented read-only MCP publication export tools: runops.publication.exports.list and runops.publication.export.inspect. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.'
+source_record: harness-lab/records/eval-cases/E0004-fb0004-mcp-publication-export-manifest-inspect.md

--- a/harness-lab/views/eval-results/E0005-manual-score.md
+++ b/harness-lab/views/eval-results/E0005-manual-score.md
@@ -1,0 +1,26 @@
+<!-- harnessops により生成; source records が正本 -->
+# 手動評価結果: E0005
+
+送信元: `harness-lab/records/eval-cases/E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md`
+
+## スコア
+
+- impact: 4
+- mechanism_clarity: 5
+- evaluability: 5
+- minimality: 4
+- regression_risk: 2
+- operator_burden: 4
+- anti_theater: 5
+- maintainability: 4
+- privacy_sanitization_risk: 5
+
+## メモ
+
+Implemented read-only MCP analysis tools: runops.analysis.artifacts, runops.survey.summary, and runops.analysis.plot_columns. They inspect existing artifacts/summary files and report missing data through envelopes without collecting or plotting. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.
+
+## 評価ケース
+
+- capability: unclassified
+- failure_class: unclassified
+- source_feedback: FB0005

--- a/harness-lab/views/eval-results/E0005-manual-score.yml
+++ b/harness-lab/views/eval-results/E0005-manual-score.yml
@@ -1,0 +1,17 @@
+schema_version: '0.1'
+record_type: manual_eval_result
+created_at: '2026-05-14T11:43:52+09:00'
+eval_case: E0005
+experiment:
+scores:
+  impact: 4
+  mechanism_clarity: 5
+  evaluability: 5
+  minimality: 4
+  regression_risk: 2
+  operator_burden: 4
+  anti_theater: 5
+  maintainability: 4
+  privacy_sanitization_risk: 5
+notes: 'Implemented read-only MCP analysis tools: runops.analysis.artifacts, runops.survey.summary, and runops.analysis.plot_columns. They inspect existing artifacts/summary files and report missing data through envelopes without collecting or plotting. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.'
+source_record: harness-lab/records/eval-cases/E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md

--- a/harness-lab/views/eval-results/E0006-manual-score.md
+++ b/harness-lab/views/eval-results/E0006-manual-score.md
@@ -1,0 +1,26 @@
+<!-- harnessops により生成; source records が正本 -->
+# 手動評価結果: E0006
+
+送信元: `harness-lab/records/eval-cases/E0006-fb0006-paper-draft-runops-research-agenda-contract.md`
+
+## スコア
+
+- impact: 3
+- mechanism_clarity: 5
+- evaluability: 5
+- minimality: 4
+- regression_risk: 2
+- operator_burden: 4
+- anti_theater: 5
+- maintainability: 4
+- privacy_sanitization_risk: 5
+
+## メモ
+
+Implemented the paper request contract with docs, schema, scaffold template, and read/plan MCP tools: runops.paper.requests.list and runops.paper.request.plan. The tools do not mutate files or submit jobs. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.
+
+## 評価ケース
+
+- capability: unclassified
+- failure_class: unclassified
+- source_feedback: FB0006

--- a/harness-lab/views/eval-results/E0006-manual-score.yml
+++ b/harness-lab/views/eval-results/E0006-manual-score.yml
@@ -1,0 +1,17 @@
+schema_version: '0.1'
+record_type: manual_eval_result
+created_at: '2026-05-14T11:44:00+09:00'
+eval_case: E0006
+experiment:
+scores:
+  impact: 3
+  mechanism_clarity: 5
+  evaluability: 5
+  minimality: 4
+  regression_risk: 2
+  operator_burden: 4
+  anti_theater: 5
+  maintainability: 4
+  privacy_sanitization_risk: 5
+notes: 'Implemented the paper request contract with docs, schema, scaffold template, and read/plan MCP tools: runops.paper.requests.list and runops.paper.request.plan. The tools do not mutate files or submit jobs. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.'
+source_record: harness-lab/records/eval-cases/E0006-fb0006-paper-draft-runops-research-agenda-contract.md

--- a/schemas/paper_requests.json
+++ b/schemas/paper_requests.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://runops.dev/schemas/paper_requests.json",
+  "title": "runops paper-facing request queue",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "requests"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "requests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "id",
+          "type",
+          "title",
+          "paper_context",
+          "desired_artifact",
+          "source_link",
+          "priority",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "analysis_request",
+              "figure_request",
+              "experiment_request",
+              "evidence_gap",
+              "export_request"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "paper_id": {
+            "type": "string"
+          },
+          "paper_context": {
+            "type": "string",
+            "minLength": 1
+          },
+          "desired_artifact": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_link": {
+            "type": "string",
+            "minLength": 1
+          },
+          "related_runs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "related_surveys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "urgent"]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "planned",
+              "in_progress",
+              "blocked",
+              "done",
+              "rejected"
+            ]
+          },
+          "human_gate": {
+            "type": "boolean"
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/runops/cli/init/scaffold.py
+++ b/src/runops/cli/init/scaffold.py
@@ -127,6 +127,12 @@ def _create_research_skeleton(project_dir: Path, created: list[str]) -> None:
     agenda_path = research_dir / "agenda.md"
     if _write_if_missing(agenda_path, load_static("scaffold/research/agenda.md")):
         created.append("research/agenda.md")
+    paper_requests_path = research_dir / "paper_requests.toml"
+    if _write_if_missing(
+        paper_requests_path,
+        load_static("scaffold/research/paper_requests.toml"),
+    ):
+        created.append("research/paper_requests.toml")
     for dirname in ("proposals", "reviews"):
         keep_path = research_dir / dirname / ".gitkeep"
         template_path = f"scaffold/research/{dirname}/.gitkeep"

--- a/src/runops/cli/update_harness.py
+++ b/src/runops/cli/update_harness.py
@@ -120,6 +120,7 @@ def _missing_workspace_scaffold(
                 "research/",
                 "research/README.md",
                 "research/agenda.md",
+                "research/paper_requests.toml",
                 "research/proposals/",
                 "research/proposals/.gitkeep",
                 "research/reviews/",

--- a/src/runops/core/migrations/v0.py
+++ b/src/runops/core/migrations/v0.py
@@ -174,6 +174,11 @@ def apply_research_agenda_scaffold(context: MigrationContext) -> MigrationResult
             Path("research/agenda.md"), "file", "scaffold/research/agenda.md"
         ),
         _ScaffoldTarget(
+            Path("research/paper_requests.toml"),
+            "file",
+            "scaffold/research/paper_requests.toml",
+        ),
+        _ScaffoldTarget(
             Path("research/proposals/.gitkeep"),
             "file",
             "scaffold/research/proposals/.gitkeep",

--- a/src/runops/mcp/registry.py
+++ b/src/runops/mcp/registry.py
@@ -78,6 +78,41 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         "Diagnose project configuration without mutating project files.",
         READ,
     ),
+    ToolSpec(
+        "runops.publication.exports.list",
+        "List paper-facing publication exports without mutating files.",
+        READ,
+    ),
+    ToolSpec(
+        "runops.publication.export.inspect",
+        "Inspect one publication export manifest without mutating files.",
+        INSPECT,
+    ),
+    ToolSpec(
+        "runops.analysis.artifacts",
+        "Inspect run or survey analysis artifact indexes.",
+        INSPECT,
+    ),
+    ToolSpec(
+        "runops.survey.summary",
+        "Inspect an existing survey summary aggregate.",
+        INSPECT,
+    ),
+    ToolSpec(
+        "runops.analysis.plot_columns",
+        "List survey plot columns from an existing summary aggregate.",
+        INSPECT,
+    ),
+    ToolSpec(
+        "runops.paper.requests.list",
+        "List paper-facing requests from the project research layer.",
+        READ,
+    ),
+    ToolSpec(
+        "runops.paper.request.plan",
+        "Plan how to route a paper-facing request without mutating files.",
+        PLAN,
+    ),
     ToolSpec("runops.run.list", "List run directories and manifest states.", READ),
     ToolSpec("runops.run.inspect", "Inspect one run manifest and readiness.", INSPECT),
     ToolSpec("runops.run.logs", "Return tail lines from the latest run log.", INSPECT),
@@ -130,9 +165,16 @@ REQUIRED_COMMON_TOOLS = {
 }
 
 REQUIRED_RUNOPS_TOOLS = REQUIRED_COMMON_TOOLS | {
+    "runops.analysis.artifacts",
+    "runops.analysis.plot_columns",
+    "runops.paper.request.plan",
+    "runops.paper.requests.list",
+    "runops.publication.export.inspect",
+    "runops.publication.exports.list",
     "runops.run.list",
     "runops.run.inspect",
     "runops.run.logs",
+    "runops.survey.summary",
     "runops.slurm.queue",
     "runops.job.plan_submit",
 }

--- a/src/runops/mcp/server.py
+++ b/src/runops/mcp/server.py
@@ -102,6 +102,124 @@ def _register_tools(mcp: FastMCP) -> None:
         return tools.project_doctor(project_root=project_root)
 
     @mcp.tool(
+        name="runops.publication.exports.list",
+        description="List paper-facing publication exports without mutating files.",
+        structured_output=True,
+    )
+    def publication_exports_list(
+        project_root: str | None = None,
+        paper_id: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        return tools.publication_exports_list(
+            project_root=project_root,
+            paper_id=paper_id,
+            limit=limit,
+        )
+
+    @mcp.tool(
+        name="runops.publication.export.inspect",
+        description="Inspect one publication export manifest without mutating files.",
+        structured_output=True,
+    )
+    def publication_export_inspect(
+        project_root: str | None = None,
+        export: str | None = None,
+        paper_id: str | None = None,
+        name: str | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        return tools.publication_export_inspect(
+            project_root=project_root,
+            export=export,
+            paper_id=paper_id,
+            name=name,
+            limit=limit,
+        )
+
+    @mcp.tool(
+        name="runops.analysis.artifacts",
+        description="Inspect run or survey analysis artifact indexes.",
+        structured_output=True,
+    )
+    def analysis_artifacts(
+        target: str,
+        project_root: str | None = None,
+        kind: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        return tools.analysis_artifacts(
+            target=target,
+            project_root=project_root,
+            kind=kind,
+            limit=limit,
+        )
+
+    @mcp.tool(
+        name="runops.survey.summary",
+        description="Inspect an existing survey summary aggregate.",
+        structured_output=True,
+    )
+    def survey_summary(
+        survey: str,
+        project_root: str | None = None,
+        include_runs: bool = False,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        return tools.survey_summary(
+            survey=survey,
+            project_root=project_root,
+            include_runs=include_runs,
+            limit=limit,
+        )
+
+    @mcp.tool(
+        name="runops.analysis.plot_columns",
+        description="List survey plot columns from an existing summary aggregate.",
+        structured_output=True,
+    )
+    def analysis_plot_columns(
+        survey: str,
+        project_root: str | None = None,
+    ) -> dict[str, Any]:
+        return tools.analysis_plot_columns(
+            survey=survey,
+            project_root=project_root,
+        )
+
+    @mcp.tool(
+        name="runops.paper.requests.list",
+        description="List paper-facing requests from the project research layer.",
+        structured_output=True,
+    )
+    def paper_requests_list(
+        project_root: str | None = None,
+        paper_id: str | None = None,
+        status_filter: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        return tools.paper_requests_list(
+            project_root=project_root,
+            paper_id=paper_id,
+            status_filter=status_filter,
+            limit=limit,
+        )
+
+    @mcp.tool(
+        name="runops.paper.request.plan",
+        description="Plan how to route a paper-facing request without mutating files.",
+        structured_output=True,
+    )
+    def paper_request_plan(
+        request_id: str,
+        project_root: str | None = None,
+    ) -> dict[str, Any]:
+        return tools.paper_request_plan(
+            request_id=request_id,
+            project_root=project_root,
+        )
+
+    @mcp.tool(
         name="runops.run.list",
         description="List run directories and manifest states.",
         structured_output=True,

--- a/src/runops/mcp/tools.py
+++ b/src/runops/mcp/tools.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import shutil
+import sys
 from collections import Counter
 from pathlib import Path
 from time import perf_counter
 from typing import Any
 
 from runops import __version__
+from runops.core.analysis.artifacts import read_artifacts_index
 from runops.core.context import build_project_context
 from runops.core.discovery import discover_runs, resolve_run, validate_uniqueness
 from runops.core.exceptions import SimctlError
@@ -32,6 +35,11 @@ from runops.mcp.schemas import (
 )
 from runops.slurm.query import SlurmQueryError, query_job_status
 from runops.slurm.submit import SlurmNotFoundError
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 def _tool_start() -> tuple[str, float]:
@@ -117,6 +125,288 @@ def _find_latest_log(work_dir: Path, patterns: list[str]) -> Path | None:
 def _tail_text(path: Path, lines: int) -> list[str]:
     content = path.read_text(encoding="utf-8", errors="replace").splitlines()
     return content[-lines:] if len(content) > lines else content
+
+
+def _safe_limit(limit: int, *, default: int = 100, maximum: int = 1000) -> int:
+    if limit <= 0:
+        return default
+    return min(limit, maximum)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise SimctlError(f"Invalid JSON object at {path}")
+    return data
+
+
+def _load_toml_object(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    if not isinstance(data, dict):
+        raise SimctlError(f"Invalid TOML object at {path}")
+    return data
+
+
+def _slugify_token(value: str) -> str:
+    text = value.strip().lower()
+    chars: list[str] = []
+    last_dash = False
+    for ch in text:
+        if ch.isalnum():
+            chars.append(ch)
+            last_dash = False
+            continue
+        if (ch in {"-", "_", ".", "/"} or ch.isspace()) and not last_dash:
+            chars.append("-")
+            last_dash = True
+    return "".join(chars).strip("-")
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _publication_manifest_row(
+    project_root: Path,
+    export_dir: Path,
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    export_section = manifest.get("export", {})
+    if not isinstance(export_section, dict):
+        export_section = {}
+    paper_section = manifest.get("paper", {})
+    if not isinstance(paper_section, dict):
+        paper_section = {}
+
+    paper_id = str(
+        manifest.get("paper_id") or paper_section.get("id") or export_dir.parent.name
+    )
+    export_name = str(
+        manifest.get("export_name") or export_section.get("name") or export_dir.name
+    )
+    export_id = str(export_section.get("id") or f"{paper_id}/{export_name}")
+    manifest_warnings = manifest.get("warnings", [])
+    if not isinstance(manifest_warnings, list):
+        manifest_warnings = []
+
+    return {
+        "id": export_id,
+        "paper_id": paper_id,
+        "export_name": export_name,
+        "target_kind": str(manifest.get("target_kind", "")),
+        "source_run_ids": _normalize_string_list(manifest.get("source_run_ids", [])),
+        "created_at": str(
+            manifest.get("created_at") or export_section.get("created_at") or ""
+        ),
+        "manifest_path": _relative_or_absolute(
+            export_dir / "manifest.json", project_root
+        ),
+        "manifest_abspath": str(export_dir / "manifest.json"),
+        "readme_path": _relative_or_absolute(export_dir / "README.md", project_root),
+        "readme_abspath": str(export_dir / "README.md"),
+        "warning_count": len(manifest_warnings),
+        "valid": True,
+    }
+
+
+def _broken_publication_export_row(
+    project_root: Path,
+    export_dir: Path,
+    message: str,
+) -> dict[str, Any]:
+    paper_id = export_dir.parent.name
+    export_name = export_dir.name
+    return {
+        "id": f"{paper_id}/{export_name}",
+        "paper_id": paper_id,
+        "export_name": export_name,
+        "target_kind": "",
+        "source_run_ids": [],
+        "created_at": "",
+        "manifest_path": _relative_or_absolute(
+            export_dir / "manifest.json", project_root
+        ),
+        "manifest_abspath": str(export_dir / "manifest.json"),
+        "readme_path": _relative_or_absolute(export_dir / "README.md", project_root),
+        "readme_abspath": str(export_dir / "README.md"),
+        "warning_count": 1,
+        "valid": False,
+        "error": message,
+    }
+
+
+def _resolve_publication_export_dir(
+    project_root: Path,
+    *,
+    export: str | None,
+    paper_id: str | None,
+    name: str | None,
+) -> Path:
+    if export:
+        candidate = Path(export).expanduser()
+        if candidate.is_absolute() and candidate.is_dir():
+            return candidate.resolve()
+        relative = (project_root / candidate).resolve()
+        if relative.is_dir():
+            return relative
+        parts = export.replace("\\", "/").strip("/").split("/")
+        if len(parts) == 2:
+            return (
+                project_root
+                / "exports"
+                / "papers"
+                / _slugify_token(parts[0])
+                / _slugify_token(parts[1])
+            ).resolve()
+
+    if paper_id and name:
+        return (
+            project_root
+            / "exports"
+            / "papers"
+            / _slugify_token(paper_id)
+            / _slugify_token(name)
+        ).resolve()
+
+    raise SimctlError("Specify export or paper_id + name.")
+
+
+def _resolve_run_or_survey_target(target: str, project_root: Path) -> tuple[str, Path]:
+    candidate = Path(target).expanduser()
+    candidates: list[Path] = []
+    if candidate.is_absolute():
+        candidates.append(candidate.resolve())
+    else:
+        candidates.append((project_root / candidate).resolve())
+        candidates.append((Path.cwd() / candidate).resolve())
+
+    for path in candidates:
+        if (path / "manifest.toml").is_file():
+            return "run", path
+        if path.is_dir() and discover_runs(path):
+            return "survey", path
+
+    run_dir = resolve_run(target, project_root / "runs")
+    return "run", run_dir
+
+
+def _resolve_survey_dir(survey: str, project_root: Path) -> Path:
+    kind, path = _resolve_run_or_survey_target(survey, project_root)
+    if kind != "survey":
+        raise SimctlError(f"Target is not a survey directory: {survey}")
+    return path
+
+
+def _artifact_payload(
+    project_root: Path,
+    base_dir: Path,
+    artifact: dict[str, Any],
+) -> dict[str, Any]:
+    payload = dict(artifact)
+    rel_path = str(artifact.get("path", "")).strip()
+    payload["relative_path"] = rel_path
+    if rel_path:
+        artifact_path = (base_dir / rel_path).resolve()
+        payload["absolute_path"] = str(artifact_path)
+        payload["project_relative_path"] = _relative_or_absolute(
+            artifact_path,
+            project_root,
+        )
+    else:
+        payload["absolute_path"] = ""
+        payload["project_relative_path"] = ""
+    return payload
+
+
+def _flatten_mapping(data: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+    flat: dict[str, Any] = {}
+    for key, value in data.items():
+        flat_key = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(value, dict):
+            flat.update(_flatten_mapping(value, flat_key))
+            continue
+        flat[flat_key] = value
+    return flat
+
+
+def _survey_plot_columns_from_aggregate(aggregate: dict[str, Any]) -> list[str]:
+    columns: set[str] = set()
+    runs = aggregate.get("runs", [])
+    if isinstance(runs, list):
+        for item in runs:
+            if not isinstance(item, dict):
+                continue
+            row = {
+                "run_id": item.get("run_id", ""),
+                "display_name": item.get("display_name", ""),
+                "status": item.get("status", ""),
+            }
+            for key in (
+                "analysis_status",
+                "analysis_ready",
+                "simulator_status",
+                "summary_available",
+                "summary_status",
+                "summary_partial",
+                "missing_required_artifacts",
+            ):
+                if key in item:
+                    row[key] = item[key]
+            flat_metadata = item.get("flat_metadata", {})
+            if isinstance(flat_metadata, dict):
+                row.update(flat_metadata)
+            flat_summary = item.get("flat_summary", {})
+            if isinstance(flat_summary, dict):
+                row.update(flat_summary)
+            columns.update(row)
+
+    preferred = [
+        "run_id",
+        "display_name",
+        "status",
+        "analysis_status",
+        "analysis_ready",
+        "simulator_status",
+        "summary_available",
+        "summary_status",
+        "summary_partial",
+        "missing_required_artifacts",
+    ]
+    return [
+        *[column for column in preferred if column in columns],
+        *sorted(columns - set(preferred)),
+    ]
+
+
+def _load_paper_requests(project_root: Path) -> tuple[Path, list[dict[str, Any]]]:
+    path = project_root / "research" / "paper_requests.toml"
+    data = _load_toml_object(path)
+    raw_requests = data.get("requests", [])
+    if not isinstance(raw_requests, list):
+        raise SimctlError("research/paper_requests.toml must contain [[requests]].")
+    return path, [item for item in raw_requests if isinstance(item, dict)]
+
+
+def _paper_request_row(
+    request: dict[str, Any],
+    *,
+    project_root: Path,
+    schema_path: Path,
+) -> dict[str, Any]:
+    row = dict(request)
+    row["id"] = str(request.get("id", "")).strip()
+    row["type"] = str(request.get("type", "")).strip()
+    row["title"] = str(request.get("title", "")).strip()
+    row["priority"] = str(request.get("priority", "")).strip() or "medium"
+    row["status"] = str(request.get("status", "")).strip() or "open"
+    row["schema_path"] = _relative_or_absolute(schema_path, project_root)
+    for key in ("related_runs", "related_surveys"):
+        row[key] = _normalize_string_list(request.get(key, []))
+    return row
 
 
 def health() -> dict[str, Any]:
@@ -368,6 +658,715 @@ def project_doctor(project_root: str | None = None) -> dict[str, Any]:
             warning(str(check["name"]), str(check["message"]), severity="medium")
             for check in failed
         ],
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def publication_exports_list(
+    project_root: str | None = None,
+    paper_id: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List existing publication export manifests without creating files."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.publication.exports.list")
+    inputs = {"project_root": project_root, "paper_id": paper_id, "limit": limit}
+    try:
+        root = _resolve_project_root(project_root)
+    except SimctlError as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="project_not_found",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    paper_root = root / "exports" / "papers"
+    if not paper_root.is_dir():
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="ok",
+            summary="No publication exports found.",
+            data={"exports": [], "matched_count": 0, "total_count": 0},
+            project_root=root,
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    paper_dirs = [path for path in sorted(paper_root.iterdir()) if path.is_dir()]
+    if paper_id:
+        token = _slugify_token(paper_id)
+        paper_dirs = [path for path in paper_dirs if path.name == token]
+
+    rows: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    for paper_dir in paper_dirs:
+        for export_dir in sorted(path for path in paper_dir.iterdir() if path.is_dir()):
+            manifest_path = export_dir / "manifest.json"
+            if not manifest_path.is_file():
+                message = (
+                    f"Missing manifest.json for {paper_dir.name}/{export_dir.name}"
+                )
+                rows.append(_broken_publication_export_row(root, export_dir, message))
+                warnings.append(warning("manifest_missing", message, severity="low"))
+                continue
+            try:
+                manifest = _load_json_object(manifest_path)
+            except (OSError, json.JSONDecodeError, SimctlError) as exc:
+                message = f"Invalid manifest {manifest_path}: {exc}"
+                rows.append(_broken_publication_export_row(root, export_dir, message))
+                warnings.append(warning("manifest_invalid", message))
+                continue
+            rows.append(_publication_manifest_row(root, export_dir, manifest))
+
+    safe_limit = _safe_limit(limit)
+    clipped = rows[:safe_limit]
+    if len(rows) > len(clipped):
+        warnings.append(
+            warning(
+                "result_limited",
+                f"Returned {len(clipped)} of {len(rows)} publication exports.",
+                severity="low",
+            )
+        )
+    status: EnvelopeStatus = "warning" if warnings else "ok"
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status=status,
+        summary=f"{len(rows)} publication export(s) matched.",
+        data={
+            "exports": clipped,
+            "matched_count": len(rows),
+            "total_count": sum(
+                1
+                for paper_dir in paper_dirs
+                for path in paper_dir.iterdir()
+                if path.is_dir()
+            ),
+        },
+        project_root=root,
+        warnings=warnings,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def publication_export_inspect(
+    project_root: str | None = None,
+    export: str | None = None,
+    paper_id: str | None = None,
+    name: str | None = None,
+    limit: int = 200,
+) -> dict[str, Any]:
+    """Inspect one publication export manifest without mutating files."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.publication.export.inspect")
+    inputs = {
+        "project_root": project_root,
+        "export": export,
+        "paper_id": paper_id,
+        "name": name,
+        "limit": limit,
+    }
+    try:
+        root = _resolve_project_root(project_root)
+        export_dir = _resolve_publication_export_dir(
+            root,
+            export=export,
+            paper_id=paper_id,
+            name=name,
+        )
+    except SimctlError as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="export_not_found",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    manifest_path = export_dir / "manifest.json"
+    if not export_dir.is_dir() or not manifest_path.is_file():
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="manifest_not_found",
+            message=f"Publication export manifest not found: {manifest_path}",
+            project_root=root,
+            inputs=inputs,
+        )
+
+    try:
+        manifest = _load_json_object(manifest_path)
+    except (OSError, json.JSONDecodeError, SimctlError) as exc:
+        message = f"Invalid manifest {manifest_path}: {exc}"
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={
+                "export": _broken_publication_export_row(root, export_dir, message),
+                "manifest": {},
+                "files": [],
+                "file_count": 0,
+                "source": {},
+            },
+            project_root=root,
+            warnings=[warning("manifest_invalid", message)],
+            errors=[error("manifest_invalid", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    files = manifest.get("files", [])
+    if not isinstance(files, list):
+        files = []
+    safe_limit = _safe_limit(limit, default=200)
+    clipped_files = [item for item in files if isinstance(item, dict)][:safe_limit]
+    warnings = []
+    if len(files) > len(clipped_files):
+        warnings.append(
+            warning(
+                "result_limited",
+                f"Returned {len(clipped_files)} of {len(files)} exported files.",
+                severity="low",
+            )
+        )
+    manifest_warnings = manifest.get("warnings", [])
+    if not isinstance(manifest_warnings, list):
+        manifest_warnings = []
+    for item in manifest_warnings:
+        warnings.append(warning("manifest_warning", str(item), severity="low"))
+
+    source = manifest.get("source", {})
+    if not isinstance(source, dict):
+        source = {}
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status="warning" if warnings else "ok",
+        summary=(
+            f"Publication export {export_dir.parent.name}/{export_dir.name} inspected."
+        ),
+        data={
+            "export": _publication_manifest_row(root, export_dir, manifest),
+            "manifest": manifest,
+            "files": clipped_files,
+            "file_count": len(files),
+            "source": source,
+            "manifest_warnings": manifest_warnings,
+        },
+        project_root=root,
+        warnings=warnings,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def analysis_artifacts(
+    target: str,
+    project_root: str | None = None,
+    kind: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Inspect run or survey analysis artifact rows without collecting outputs."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.analysis.artifacts")
+    inputs = {
+        "target": target,
+        "project_root": project_root,
+        "kind": kind,
+        "limit": limit,
+    }
+    try:
+        root = _resolve_project_root(project_root)
+        target_kind, target_dir = _resolve_run_or_survey_target(target, root)
+    except SimctlError as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="target_not_found",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    if target_kind == "run":
+        index_path = target_dir / "analysis" / "artifacts.toml"
+        base_dir = target_dir / "analysis"
+    else:
+        index_path = target_dir / "summary" / "artifacts.toml"
+        base_dir = target_dir / "summary"
+
+    if not index_path.is_file():
+        message = f"Artifact index not found: {_relative_or_absolute(index_path, root)}"
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={
+                "target_kind": target_kind,
+                "target_path": _relative_or_absolute(target_dir, root),
+                "artifacts": [],
+                "matched_count": 0,
+                "index_path": _relative_or_absolute(index_path, root),
+            },
+            project_root=root,
+            warnings=[warning("artifacts_missing", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    try:
+        raw_artifacts = read_artifacts_index(index_path)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        message = f"Invalid artifact index {index_path}: {exc}"
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={"artifacts": [], "matched_count": 0},
+            project_root=root,
+            warnings=[warning("artifacts_invalid", message)],
+            errors=[error("artifacts_invalid", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    normalized_kind = kind.strip() if kind else ""
+    artifacts = [
+        _artifact_payload(root, base_dir, item)
+        for item in raw_artifacts
+        if not normalized_kind or str(item.get("kind", "")) == normalized_kind
+    ]
+    safe_limit = _safe_limit(limit)
+    clipped = artifacts[:safe_limit]
+    warnings = []
+    if len(artifacts) > len(clipped):
+        warnings.append(
+            warning(
+                "result_limited",
+                f"Returned {len(clipped)} of {len(artifacts)} artifacts.",
+                severity="low",
+            )
+        )
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status="warning" if warnings else "ok",
+        summary=f"{len(artifacts)} artifact(s) matched.",
+        data={
+            "target_kind": target_kind,
+            "target_path": _relative_or_absolute(target_dir, root),
+            "index_path": _relative_or_absolute(index_path, root),
+            "artifacts": clipped,
+            "matched_count": len(artifacts),
+        },
+        project_root=root,
+        warnings=warnings,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def survey_summary(
+    survey: str,
+    project_root: str | None = None,
+    include_runs: bool = False,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Inspect an existing survey_summary.json without collecting summaries."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.survey.summary")
+    inputs = {
+        "survey": survey,
+        "project_root": project_root,
+        "include_runs": include_runs,
+        "limit": limit,
+    }
+    try:
+        root = _resolve_project_root(project_root)
+        survey_dir = _resolve_survey_dir(survey, root)
+    except SimctlError as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="survey_not_found",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    summary_path = survey_dir / "summary" / "survey_summary.json"
+    if not summary_path.is_file():
+        message = (
+            f"Survey summary not found: {_relative_or_absolute(summary_path, root)}"
+        )
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={
+                "survey_path": _relative_or_absolute(survey_dir, root),
+                "summary_path": _relative_or_absolute(summary_path, root),
+                "runs": [],
+            },
+            project_root=root,
+            warnings=[warning("survey_summary_missing", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    try:
+        aggregate = _load_json_object(summary_path)
+    except (OSError, json.JSONDecodeError, SimctlError) as exc:
+        message = f"Invalid survey summary {summary_path}: {exc}"
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={"runs": []},
+            project_root=root,
+            warnings=[warning("survey_summary_invalid", message)],
+            errors=[error("survey_summary_invalid", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    runs = aggregate.get("runs", [])
+    if not isinstance(runs, list):
+        runs = []
+    safe_limit = _safe_limit(limit)
+    summary_warnings = aggregate.get("warnings", [])
+    if not isinstance(summary_warnings, list):
+        summary_warnings = []
+    warnings = [
+        warning("survey_summary_warning", str(item), severity="low")
+        for item in summary_warnings
+    ]
+    data = {
+        "survey_path": _relative_or_absolute(survey_dir, root),
+        "summary_path": _relative_or_absolute(summary_path, root),
+        "total_runs": aggregate.get("total_runs", len(runs)),
+        "summaries_collected": aggregate.get("summaries_collected", 0),
+        "missing_summaries": aggregate.get("missing_summaries", 0),
+        "state_counts": aggregate.get("state_counts", {}),
+        "readiness_counts": aggregate.get("readiness_counts", {}),
+        "numeric_stats": aggregate.get("numeric_stats", {}),
+        "readiness_issues": aggregate.get("readiness_issues", []),
+        "warning_count": len(summary_warnings),
+        "run_count": len(runs),
+    }
+    if include_runs:
+        data["runs"] = runs[:safe_limit]
+        if len(runs) > safe_limit:
+            warnings.append(
+                warning(
+                    "result_limited",
+                    f"Returned {safe_limit} of {len(runs)} survey runs.",
+                    severity="low",
+                )
+            )
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status="warning" if warnings else "ok",
+        summary=f"Survey summary has {len(runs)} run row(s).",
+        data=data,
+        project_root=root,
+        warnings=warnings,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def analysis_plot_columns(
+    survey: str,
+    project_root: str | None = None,
+) -> dict[str, Any]:
+    """List plot columns from an existing survey_summary.json without collecting."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.analysis.plot_columns")
+    inputs = {"survey": survey, "project_root": project_root}
+    try:
+        root = _resolve_project_root(project_root)
+        survey_dir = _resolve_survey_dir(survey, root)
+    except SimctlError as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="survey_not_found",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    summary_path = survey_dir / "summary" / "survey_summary.json"
+    if not summary_path.is_file():
+        message = (
+            f"Survey summary not found: {_relative_or_absolute(summary_path, root)}"
+        )
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={"columns": []},
+            project_root=root,
+            warnings=[warning("survey_summary_missing", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    try:
+        aggregate = _load_json_object(summary_path)
+    except (OSError, json.JSONDecodeError, SimctlError) as exc:
+        message = f"Invalid survey summary {summary_path}: {exc}"
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={"columns": []},
+            project_root=root,
+            warnings=[warning("survey_summary_invalid", message)],
+            errors=[error("survey_summary_invalid", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    columns = _survey_plot_columns_from_aggregate(aggregate)
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status="ok",
+        summary=f"{len(columns)} plot column(s) available.",
+        data={
+            "survey_path": _relative_or_absolute(survey_dir, root),
+            "summary_path": _relative_or_absolute(summary_path, root),
+            "columns": columns,
+        },
+        project_root=root,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def paper_requests_list(
+    project_root: str | None = None,
+    paper_id: str | None = None,
+    status_filter: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List paper-facing requests from research/paper_requests.toml."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.paper.requests.list")
+    inputs = {
+        "project_root": project_root,
+        "paper_id": paper_id,
+        "status_filter": status_filter,
+        "limit": limit,
+    }
+    try:
+        root = _resolve_project_root(project_root)
+    except SimctlError as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="project_not_found",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    schema_path = root / "research" / "paper_requests.toml"
+    if not schema_path.is_file():
+        message = "research/paper_requests.toml not found."
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={
+                "requests": [],
+                "matched_count": 0,
+                "schema_path": _relative_or_absolute(schema_path, root),
+            },
+            project_root=root,
+            warnings=[warning("paper_requests_missing", message, severity="low")],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    try:
+        schema_path, raw_requests = _load_paper_requests(root)
+    except (OSError, tomllib.TOMLDecodeError, SimctlError) as exc:
+        message = f"Invalid paper request file {schema_path}: {exc}"
+        return envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            status="warning",
+            summary=message,
+            data={"requests": [], "matched_count": 0},
+            project_root=root,
+            warnings=[warning("paper_requests_invalid", message)],
+            errors=[error("paper_requests_invalid", message)],
+            started_at=started_at,
+            started_perf=started_perf,
+            inputs=inputs,
+        )
+
+    rows = [
+        _paper_request_row(item, project_root=root, schema_path=schema_path)
+        for item in raw_requests
+    ]
+    if paper_id:
+        rows = [row for row in rows if str(row.get("paper_id", "")) == paper_id]
+    if status_filter:
+        rows = [row for row in rows if row["status"] == status_filter]
+    safe_limit = _safe_limit(limit)
+    clipped = rows[:safe_limit]
+    warnings = []
+    if len(rows) > safe_limit:
+        warnings.append(
+            warning(
+                "result_limited",
+                f"Returned {safe_limit} of {len(rows)} paper requests.",
+                severity="low",
+            )
+        )
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status="warning" if warnings else "ok",
+        summary=f"{len(rows)} paper request(s) matched.",
+        data={
+            "requests": clipped,
+            "matched_count": len(rows),
+            "schema_path": _relative_or_absolute(schema_path, root),
+        },
+        project_root=root,
+        warnings=warnings,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
+def paper_request_plan(
+    request_id: str,
+    project_root: str | None = None,
+) -> dict[str, Any]:
+    """Plan how to route one paper-facing request without mutating files."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.paper.request.plan")
+    inputs = {"request_id": request_id, "project_root": project_root}
+    try:
+        root = _resolve_project_root(project_root)
+        schema_path, raw_requests = _load_paper_requests(root)
+    except (OSError, tomllib.TOMLDecodeError, SimctlError) as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="paper_requests_unavailable",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    rows = [
+        _paper_request_row(item, project_root=root, schema_path=schema_path)
+        for item in raw_requests
+    ]
+    request = next((row for row in rows if row["id"] == request_id), None)
+    if request is None:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="paper_request_not_found",
+            message=f"Paper request not found: {request_id}",
+            project_root=root,
+            inputs=inputs,
+        )
+
+    request_type = str(request.get("type", ""))
+    proposal_needed = request_type in {"experiment_request", "evidence_gap"}
+    route = "research/agenda.md"
+    if proposal_needed or request.get("human_gate"):
+        route = "research/proposals/"
+    planned_actions = [
+        {
+            "title": "Review the paper request",
+            "kind": "plan",
+            "target": request["id"],
+            "requires_user": True,
+        },
+        {
+            "title": f"Record current decision in {route}",
+            "kind": "plan",
+            "target": route,
+            "requires_user": True,
+        },
+    ]
+    if request_type == "export_request":
+        planned_actions.append(
+            {
+                "title": "Inspect available publication exports",
+                "kind": "plan",
+                "tool": "runops.publication.exports.list",
+                "requires_user": False,
+            }
+        )
+    elif request_type in {"analysis_request", "figure_request"}:
+        planned_actions.append(
+            {
+                "title": "Inspect analysis artifacts and survey summaries",
+                "kind": "plan",
+                "tool": "runops.analysis.artifacts",
+                "requires_user": False,
+            }
+        )
+    elif request_type == "experiment_request":
+        planned_actions.append(
+            {
+                "title": "Design a case or survey; do not submit jobs automatically",
+                "kind": "plan",
+                "requires_user": True,
+            }
+        )
+
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status="ok",
+        summary=f"Paper request {request_id} planned without side effects.",
+        data={
+            "request": request,
+            "route": route,
+            "will_submit": False,
+            "will_mutate_files": False,
+        },
+        project_root=root,
+        next_actions=planned_actions,
         started_at=started_at,
         started_perf=started_perf,
         inputs=inputs,

--- a/src/runops/templates/scaffold/research/README.md
+++ b/src/runops/templates/scaffold/research/README.md
@@ -4,6 +4,7 @@
 時系列の作業ログではなく、実行管理ログでもありません。
 
 - `agenda.md` — mutable な現在の研究判断の正本
+- `paper_requests.toml` — paper draft から戻る解析・図表・追加実験要望
 - `proposals/` — 高コスト・方向転換・新 model など、実行前に残す任意の判断記録
 - `reviews/` — 主要結果・意外な失敗・pause/kill/pivot などの checkpoint snapshot
 
@@ -18,6 +19,7 @@
 | `notes/YYYY-MM-DD.md` | 日次 lab notebook | append-only |
 | `notes/reports/` | 整理済み long-form report | 改稿可 |
 | `research/agenda.md` | 現在の研究判断 | mutable |
+| `research/paper_requests.toml` | paper draft 由来の要望 | structured queue |
 | `research/proposals/` | 実行前の重い判断 | 必要時に新規作成 |
 | `research/reviews/` | 過去判断の snapshot | checkpoint ごとに新規作成 |
 | `.runops/` | runops の機械状態・curated knowledge | runops command / skill で管理 |
@@ -71,3 +73,13 @@
 runops 本体に戻すべき繰り返しの摩擦、missing command、docs gap、bug、
 改善案だけを書きます。共有するときは `feedback-runops` skill で HarnessOps に
 記録し、サニタイズ済み issue 下書きを作ります。
+
+## paper request
+
+paper draft から「追加解析が必要」「この条件の run を追加したい」
+「この export は placeholder 扱い」などの要望が出た場合は、
+`paper_requests.toml` に structured request として置けます。これは自動実行の
+指示ではなく、`agenda.md` や必要な proposal に戻すための handoff です。
+
+追加実験の run creation / survey expansion / submit は、必ず別の明示操作として
+扱います。

--- a/src/runops/templates/scaffold/research/paper_requests.toml
+++ b/src/runops/templates/scaffold/research/paper_requests.toml
@@ -1,0 +1,20 @@
+#:schema https://runops.dev/schemas/paper_requests.json
+schema_version = 1
+
+# Paper-facing requests are structured handoffs from a paper draft back into
+# this runops project. Keep execution explicit: requests may plan analysis,
+# export, case, or survey work, but they do not submit jobs by themselves.
+#
+# [[requests]]
+# id = "PAPER-REQ-0001"
+# type = "analysis_request"  # analysis_request | figure_request | experiment_request | evidence_gap | export_request
+# title = "Add sheath width comparison for Figure 2"
+# paper_id = "draft-a"
+# paper_context = "Results / Figure 2"
+# desired_artifact = "table or figure comparing sheath width across angle_scan"
+# source_link = "refs/links.toml#paper.draft-a"
+# related_runs = ["R20260412-0003"]
+# related_surveys = ["runs/sheath/angle_scan"]
+# priority = "medium"        # low | medium | high | urgent
+# status = "open"            # open | planned | in_progress | blocked | done | rejected
+# human_gate = true

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -205,6 +205,7 @@ class TestInit:
         assert "research/agenda.md" in content
         assert "本文は日本語" in content
         assert "判断の台帳" in codex_content
+        assert (tmp_path / "research" / "paper_requests.toml").is_file()
 
     def test_init_creates_migrate_runops_skill(self, tmp_path: Path) -> None:
         """The migrate-runops skill is rendered for Claude and Codex."""

--- a/tests/test_cli/test_migrate.py
+++ b/tests/test_cli/test_migrate.py
@@ -59,6 +59,7 @@ def test_migrate_applies_research_scaffold(tmp_path: Path) -> None:
     assert "M0-0002" in result.output
     assert "Status: applied" in result.output
     assert (tmp_path / "research" / "agenda.md").is_file()
+    assert (tmp_path / "research" / "paper_requests.toml").is_file()
 
 
 def test_migrate_dry_run_does_not_write(tmp_path: Path) -> None:
@@ -72,4 +73,6 @@ def test_migrate_dry_run_does_not_write(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "Status: planned" in result.output
     assert "research/agenda.md" in result.output
+    assert "research/paper_requests.toml" in result.output
     assert not (tmp_path / "research" / "agenda.md").exists()
+    assert not (tmp_path / "research" / "paper_requests.toml").exists()

--- a/tests/test_cli/test_update_harness.py
+++ b/tests/test_cli/test_update_harness.py
@@ -371,6 +371,7 @@ class TestUpdateHarnessBasic:
         (tmp_path / "materials" / "README.md").unlink()
         (tmp_path / "materials" / "papers").rmdir()
         (tmp_path / "research" / "agenda.md").unlink()
+        (tmp_path / "research" / "paper_requests.toml").unlink()
         (tmp_path / "research" / "reviews" / ".gitkeep").unlink()
 
         result = runner.invoke(app, ["update-harness", str(tmp_path), "--skip-pull"])
@@ -382,11 +383,13 @@ class TestUpdateHarnessBasic:
         assert (tmp_path / "materials" / "README.md").is_file()
         assert (tmp_path / "materials" / "papers").is_dir()
         assert (tmp_path / "research" / "agenda.md").is_file()
+        assert (tmp_path / "research" / "paper_requests.toml").is_file()
         assert (tmp_path / "research" / "reviews" / ".gitkeep").is_file()
         lock = load_harness_lock(tmp_path)
         assert "notes/README.md" not in lock
         assert "materials/README.md" not in lock
         assert "research/agenda.md" not in lock
+        assert "research/paper_requests.toml" not in lock
 
     def test_only_can_limit_workspace_backfill(self, tmp_path: Path) -> None:
         """--only respects visible workspace backfill targets."""

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -90,3 +90,27 @@ def test_launcher_schema_accepts_current_and_legacy_type_keys() -> None:
     assert {"required": ["type"]} in launcher_schema["anyOf"]
     assert {"required": ["kind"]} in launcher_schema["anyOf"]
     assert "kind" in launcher_schema["properties"]
+
+
+def test_paper_requests_schema_defines_request_contract() -> None:
+    """paper_requests.toml schema should describe paper-facing request rows."""
+    schema = _load_schema("paper_requests.json")
+    request_schema = schema["properties"]["requests"]["items"]
+
+    assert schema["properties"]["schema_version"]["const"] == 1
+    assert "requests" in schema["required"]
+    assert request_schema["properties"]["type"]["enum"] == [
+        "analysis_request",
+        "figure_request",
+        "experiment_request",
+        "evidence_gap",
+        "export_request",
+    ]
+    assert request_schema["properties"]["status"]["enum"] == [
+        "open",
+        "planned",
+        "in_progress",
+        "blocked",
+        "done",
+        "rejected",
+    ]

--- a/tests/test_mcp/test_server.py
+++ b/tests/test_mcp/test_server.py
@@ -49,6 +49,13 @@ _TOOL_ATTRS = {
     "runops.project.status": "project_status",
     "runops.project.inspect": "project_inspect",
     "runops.project.doctor": "project_doctor",
+    "runops.publication.exports.list": "publication_exports_list",
+    "runops.publication.export.inspect": "publication_export_inspect",
+    "runops.analysis.artifacts": "analysis_artifacts",
+    "runops.survey.summary": "survey_summary",
+    "runops.analysis.plot_columns": "analysis_plot_columns",
+    "runops.paper.requests.list": "paper_requests_list",
+    "runops.paper.request.plan": "paper_request_plan",
     "runops.run.list": "run_list",
     "runops.run.inspect": "run_inspect",
     "runops.run.logs": "run_logs",
@@ -92,6 +99,84 @@ def test_registered_tool_wrappers_delegate_to_domain_tools(
     assert fake.tools["runops.project.list"]["callback"](project_root="root") == {
         "stub": "runops.project.list",
         "kwargs": {"project_root": "root"},
+    }
+    assert fake.tools["runops.publication.exports.list"]["callback"](
+        project_root="root",
+        paper_id="draft-a",
+        limit=5,
+    ) == {
+        "stub": "runops.publication.exports.list",
+        "kwargs": {"project_root": "root", "paper_id": "draft-a", "limit": 5},
+    }
+    assert fake.tools["runops.publication.export.inspect"]["callback"](
+        project_root="root",
+        export="draft-a/fig2",
+        limit=10,
+    ) == {
+        "stub": "runops.publication.export.inspect",
+        "kwargs": {
+            "project_root": "root",
+            "export": "draft-a/fig2",
+            "paper_id": None,
+            "name": None,
+            "limit": 10,
+        },
+    }
+    assert fake.tools["runops.analysis.artifacts"]["callback"](
+        "R20260512-0001",
+        project_root="root",
+        kind="figure",
+        limit=2,
+    ) == {
+        "stub": "runops.analysis.artifacts",
+        "kwargs": {
+            "target": "R20260512-0001",
+            "project_root": "root",
+            "kind": "figure",
+            "limit": 2,
+        },
+    }
+    assert fake.tools["runops.survey.summary"]["callback"](
+        "runs/survey-a",
+        project_root="root",
+        include_runs=True,
+        limit=2,
+    ) == {
+        "stub": "runops.survey.summary",
+        "kwargs": {
+            "survey": "runs/survey-a",
+            "project_root": "root",
+            "include_runs": True,
+            "limit": 2,
+        },
+    }
+    assert fake.tools["runops.analysis.plot_columns"]["callback"](
+        "runs/survey-a",
+        project_root="root",
+    ) == {
+        "stub": "runops.analysis.plot_columns",
+        "kwargs": {"survey": "runs/survey-a", "project_root": "root"},
+    }
+    assert fake.tools["runops.paper.requests.list"]["callback"](
+        project_root="root",
+        paper_id="draft-a",
+        status_filter="open",
+        limit=2,
+    ) == {
+        "stub": "runops.paper.requests.list",
+        "kwargs": {
+            "project_root": "root",
+            "paper_id": "draft-a",
+            "status_filter": "open",
+            "limit": 2,
+        },
+    }
+    assert fake.tools["runops.paper.request.plan"]["callback"](
+        "REQ-001",
+        project_root="root",
+    ) == {
+        "stub": "runops.paper.request.plan",
+        "kwargs": {"request_id": "REQ-001", "project_root": "root"},
     }
     assert fake.tools["runops.run.list"]["callback"](
         project_root="root",
@@ -159,10 +244,17 @@ def test_registered_tool_wrappers_delegate_to_domain_tools(
 
     assert set(calls) >= {
         "runops.health",
+        "runops.analysis.artifacts",
+        "runops.analysis.plot_columns",
+        "runops.paper.request.plan",
+        "runops.paper.requests.list",
         "runops.project.list",
+        "runops.publication.export.inspect",
+        "runops.publication.exports.list",
         "runops.run.list",
         "runops.run.inspect",
         "runops.run.logs",
+        "runops.survey.summary",
         "runops.slurm.queue",
         "runops.slurm.job.inspect",
         "runops.job.plan_submit",

--- a/tests/test_mcp/test_tools.py
+++ b/tests/test_mcp/test_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from runops.core.manifest import ManifestData, write_manifest
@@ -50,6 +51,33 @@ def _make_run(project_root: Path, *, status: str = "created") -> Path:
         log_event=False,
     )
     return run_dir
+
+
+def _make_survey(project_root: Path) -> Path:
+    survey_dir = project_root / "runs" / "angle_scan"
+    run_dir = survey_dir / "R20260512-0002"
+    (run_dir / "analysis").mkdir(parents=True)
+    (run_dir / "work").mkdir()
+    write_manifest(
+        run_dir,
+        ManifestData(
+            run={
+                "id": "R20260512-0002",
+                "display_name": "survey-run",
+                "status": "completed",
+            },
+            origin={"case": "demo_case", "survey": "angle_scan"},
+            simulator={"name": "generic", "adapter": "generic"},
+            classification={"tags": ["survey"]},
+        ),
+        log_event=False,
+    )
+    return survey_dir
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def test_health_returns_contract_envelope() -> None:
@@ -138,3 +166,185 @@ def test_job_plan_submit_blocks_non_created_run(tmp_path: Path) -> None:
     assert result["status"] == "blocked"
     assert result["data"]["will_submit"] is False
     assert result["errors"][0]["code"] == "precondition_failed"
+
+
+def test_publication_exports_list_and_inspect_manifest(tmp_path: Path) -> None:
+    project_root = _make_project(tmp_path)
+    export_dir = project_root / "exports" / "papers" / "draft-a" / "fig2-baseline"
+    _write_json(
+        export_dir / "manifest.json",
+        {
+            "schema_version": 2,
+            "paper_id": "draft-a",
+            "export_name": "fig2-baseline",
+            "target_kind": "run",
+            "created_at": "2026-05-14T00:00:00+00:00",
+            "source_run_ids": ["R20260512-0001"],
+            "paper": {"id": "draft-a", "slug": "draft-a"},
+            "export": {
+                "id": "draft-a/fig2-baseline",
+                "name": "fig2-baseline",
+                "created_at": "2026-05-14T00:00:00+00:00",
+            },
+            "source": {"kind": "run", "run_count": 1},
+            "files": [
+                {
+                    "role": "run_summary",
+                    "source_path": "runs/R20260512-0001/analysis/summary.json",
+                    "export_path": "files/summary.json",
+                }
+            ],
+            "warnings": [],
+        },
+    )
+    (export_dir / "README.md").write_text("# Export\n", encoding="utf-8")
+
+    listing = tools.publication_exports_list(
+        project_root=str(project_root),
+        paper_id="draft-a",
+    )
+    inspected = tools.publication_export_inspect(
+        project_root=str(project_root),
+        export="draft-a/fig2-baseline",
+    )
+
+    assert listing["status"] == "ok"
+    assert listing["data"]["matched_count"] == 1
+    assert listing["data"]["exports"][0]["id"] == "draft-a/fig2-baseline"
+    assert inspected["status"] == "ok"
+    assert inspected["data"]["export"]["source_run_ids"] == ["R20260512-0001"]
+    assert inspected["data"]["files"][0]["role"] == "run_summary"
+
+
+def test_publication_exports_list_reports_broken_manifest(tmp_path: Path) -> None:
+    project_root = _make_project(tmp_path)
+    export_dir = project_root / "exports" / "papers" / "draft-a" / "broken"
+    export_dir.mkdir(parents=True)
+    (export_dir / "manifest.json").write_text("{bad json", encoding="utf-8")
+
+    result = tools.publication_exports_list(project_root=str(project_root))
+
+    assert result["status"] == "warning"
+    assert result["data"]["exports"][0]["valid"] is False
+    assert result["warnings"][0]["code"] == "manifest_invalid"
+
+
+def test_analysis_artifacts_reads_run_index(tmp_path: Path) -> None:
+    project_root = _make_project(tmp_path)
+    run_dir = _make_run(project_root)
+    (run_dir / "analysis" / "figures").mkdir(parents=True)
+    (run_dir / "analysis" / "figures" / "phi.png").write_bytes(b"png")
+    (run_dir / "analysis" / "artifacts.toml").write_text(
+        """
+schema_version = 1
+scope = "run"
+generated_by = "test"
+
+[[artifacts]]
+kind = "figure"
+path = "figures/phi.png"
+title = "Potential"
+status = "draft"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = tools.analysis_artifacts(
+        "R20260512-0001",
+        project_root=str(project_root),
+        kind="figure",
+    )
+
+    assert result["status"] == "ok"
+    assert result["data"]["matched_count"] == 1
+    artifact = result["data"]["artifacts"][0]
+    assert artifact["title"] == "Potential"
+    assert artifact["project_relative_path"].endswith(
+        "runs/R20260512-0001/analysis/figures/phi.png"
+    )
+
+
+def test_survey_summary_and_plot_columns_read_existing_summary(tmp_path: Path) -> None:
+    project_root = _make_project(tmp_path)
+    survey_dir = _make_survey(project_root)
+    _write_json(
+        survey_dir / "summary" / "survey_summary.json",
+        {
+            "total_runs": 1,
+            "summaries_collected": 1,
+            "missing_summaries": 0,
+            "state_counts": {"completed": 1},
+            "readiness_counts": {"ready": 1},
+            "numeric_stats": {"metric.alpha": {"count": 1.0, "mean": 0.5}},
+            "readiness_issues": [],
+            "warnings": [],
+            "runs": [
+                {
+                    "run_id": "R20260512-0002",
+                    "display_name": "survey-run",
+                    "status": "completed",
+                    "analysis_status": "ready",
+                    "analysis_ready": True,
+                    "flat_summary": {"metric.alpha": 0.5},
+                    "flat_metadata": {"param.angle": 30},
+                }
+            ],
+        },
+    )
+
+    summary = tools.survey_summary(
+        "runs/angle_scan",
+        project_root=str(project_root),
+        include_runs=True,
+    )
+    columns = tools.analysis_plot_columns(
+        "runs/angle_scan",
+        project_root=str(project_root),
+    )
+
+    assert summary["status"] == "ok"
+    assert summary["data"]["run_count"] == 1
+    assert summary["data"]["runs"][0]["run_id"] == "R20260512-0002"
+    assert columns["status"] == "ok"
+    assert "metric.alpha" in columns["data"]["columns"]
+    assert "param.angle" in columns["data"]["columns"]
+
+
+def test_paper_requests_list_and_plan(tmp_path: Path) -> None:
+    project_root = _make_project(tmp_path)
+    (project_root / "research").mkdir()
+    (project_root / "research" / "paper_requests.toml").write_text(
+        """
+schema_version = 1
+
+[[requests]]
+id = "PAPER-REQ-0001"
+type = "experiment_request"
+title = "Run one more angle"
+paper_id = "draft-a"
+paper_context = "Results section"
+desired_artifact = "comparison table"
+source_link = "refs/links.toml#paper.draft-a"
+priority = "high"
+status = "open"
+related_runs = ["R20260512-0002"]
+human_gate = true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    listing = tools.paper_requests_list(
+        project_root=str(project_root),
+        paper_id="draft-a",
+    )
+    plan = tools.paper_request_plan(
+        "PAPER-REQ-0001",
+        project_root=str(project_root),
+    )
+
+    assert listing["status"] == "ok"
+    assert listing["data"]["matched_count"] == 1
+    assert listing["data"]["requests"][0]["priority"] == "high"
+    assert plan["status"] == "ok"
+    assert plan["data"]["route"] == "research/proposals/"
+    assert plan["data"]["will_submit"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,7 @@ wheels = [
 
 [[package]]
 name = "runops"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Add read-only MCP tools for publication export discovery/inspection (#67)
- Add read-only MCP tools for analysis artifacts, survey summaries, and plot columns (#68)
- Add the paper request contract, schema, scaffold template, and read/plan MCP tools (#69)
- Record HOPS manual eval results for E0004, E0005, and E0006

## Tools Added

- `runops.publication.exports.list`
- `runops.publication.export.inspect`
- `runops.analysis.artifacts`
- `runops.survey.summary`
- `runops.analysis.plot_columns`
- `runops.paper.requests.list`
- `runops.paper.request.plan`

## Validation

- `uv run ruff check src/ tests/`
- `uv run mypy src/`
- `uv run pytest`
- `uv run ruff format --check src/ tests/`
- `uv run pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80`
- `uv run runo mcp check`
- `uvx --from harnessops hops doctor --check-overlay --check-records`

Closes #67
Closes #68
Closes #69