### PR TITLE
fix: allow empty paper request queues

### DIFF
--- a/docs/paper-requests.md
+++ b/docs/paper-requests.md
@@ -26,6 +26,8 @@ status = "open"
 human_gate = true
 ```
 
+空の queue では `[[requests]]` を省略し、`schema_version = 1` だけを置ける。
+
 `type` は `analysis_request`, `figure_request`, `experiment_request`,
 `evidence_gap`, `export_request` のいずれかにする。
 

--- a/docs/toml-reference.md
+++ b/docs/toml-reference.md
@@ -978,6 +978,8 @@ status = "open"
 human_gate = true
 ```
 
+空の queue では `[[requests]]` を省略し、`schema_version = 1` だけを置ける。
+
 `type` は `analysis_request`, `figure_request`, `experiment_request`,
 `evidence_gap`, `export_request` のいずれか。
 `priority` は `low | medium | high | urgent`、`status` は

--- a/schemas/paper_requests.json
+++ b/schemas/paper_requests.json
@@ -4,7 +4,7 @@
   "title": "runops paper-facing request queue",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "requests"],
+  "required": ["schema_version"],
   "properties": {
     "schema_version": {
       "type": "integer",

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -98,7 +98,8 @@ def test_paper_requests_schema_defines_request_contract() -> None:
     request_schema = schema["properties"]["requests"]["items"]
 
     assert schema["properties"]["schema_version"]["const"] == 1
-    assert "requests" in schema["required"]
+    assert "requests" in schema["properties"]
+    assert schema["required"] == ["schema_version"]
     assert request_schema["properties"]["type"]["enum"] == [
         "analysis_request",
         "figure_request",

--- a/tests/test_mcp/test_tools.py
+++ b/tests/test_mcp/test_tools.py
@@ -348,3 +348,18 @@ human_gate = true
     assert plan["status"] == "ok"
     assert plan["data"]["route"] == "research/proposals/"
     assert plan["data"]["will_submit"] is False
+
+
+def test_paper_requests_list_accepts_empty_queue(tmp_path: Path) -> None:
+    project_root = _make_project(tmp_path)
+    (project_root / "research").mkdir()
+    (project_root / "research" / "paper_requests.toml").write_text(
+        "schema_version = 1\n",
+        encoding="utf-8",
+    )
+
+    listing = tools.paper_requests_list(project_root=str(project_root))
+
+    assert listing["status"] == "ok"
+    assert listing["data"]["matched_count"] == 0
+    assert listing["data"]["requests"] == []


### PR DESCRIPTION
## Summary
- allow `research/paper_requests.toml` to omit `[[requests]]` for an empty queue
- keep the request item contract in the schema when `requests` is present
- add an MCP regression test for `schema_version = 1` only
- document that an empty queue may omit `[[requests]]`

## Verification
- `uv run ruff check tests/test_core/test_schemas.py tests/test_mcp/test_tools.py`
- `uv run pytest tests/test_core/test_schemas.py tests/test_mcp/test_tools.py -q`
- `uv run runo mcp check`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- `uv run mypy src/`
- `uv run pytest -q`