### PR TITLE
Reconcile paper-facing HOPS lab records

### DIFF
--- a/.harnessops/lock.json
+++ b/.harnessops/lock.json
@@ -34,8 +34,8 @@
   "managed_files": {
     "harness-lab/README.md": "sha256:789a733220c9918b65f6d7afbddb13ccc2d842485cca9426bb8e5dc52c24a797",
     "harness-lab/views/backlog.md": "sha256:0ed4436872ad24f9c73737b7f84290306dc4baaf36154b7e36be521e985b791c",
-    "harness-lab/views/imported-feedback.md": "sha256:4a18fc6dbd756bea43078d09c71d26334d33ca6f41470baec549437605ccdbd9",
-    "harness-lab/views/improvements.md": "sha256:65d8b225177090e914717eae1c62fd648467b82ce88baa0986d33b7d42d31ce5",
+    "harness-lab/views/imported-feedback.md": "sha256:cdf19e62ca4b20f1b50eab318d9a61b6c5785bc71a71e3bef46243160523ea8b",
+    "harness-lab/views/improvements.md": "sha256:612104a372f93ef043995cc20c440f644e3da8074738b7f2a4b3959b33ee2588",
     "harness-lab/views/research-scans.md": "sha256:6d61d712641e7eddc710614cf7bc59889c78e9532dc82666e4d82dadcc06cf7a",
     "harness-lab/views/score-trajectory.md": "sha256:a3d2f445609e5e9da0269ece3b10aff2414f3830bd185ad257d32ae19026b616"
   },

--- a/harness-lab/improvements/IMP0004-fb0004-mcp-publication-export-manifest-inspect.md
+++ b/harness-lab/improvements/IMP0004-fb0004-mcp-publication-export-manifest-inspect.md
@@ -1,0 +1,220 @@
+---
+id: IMP0004
+record_type: improvement_dossier
+created_at: '2026-05-15T04:08:36+09:00'
+updated_at: '2026-05-15T04:12:03+09:00'
+status: adopted
+source_type: local-implementation
+scope: runops-target
+maturity: adopted
+relation: new
+promotion_level: target-feature
+source_feedback: FB0004
+eval_cases:
+- E0004
+hypotheses:
+- H0004
+decisions:
+- D0003
+research_scans: []
+classification:
+  capability: mcp_publication_export_inspection
+  failure_class: missing_publication_export_manifest_inspect
+guard:
+  status: implemented
+  path: tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest; tests/test_mcp/test_server.py
+investigation:
+- created_at: '2026-05-15T04:08:36+09:00'
+  kind: implementation-sync
+  summary: 'PR #72 implemented read-only MCP publication export inspection for FB0004: runops.publication.exports.list and runops.publication.export.inspect read existing exports/papers manifests, preserve empty-list behavior, and report broken manifests through envelope warnings/errors.'
+  evidence_ref: 'PR #72; issue #67; src/runops/mcp/tools.py; src/runops/mcp/server.py; docs/mcp.md; tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest'
+links:
+  issue_url: https://github.com/Nkzono99/runops/issues/67
+---
+
+# IMP0004: FB0004: MCP から publication export 一覧と manifest を inspect できるようにする
+
+## Status
+
+- status: adopted
+- maturity: adopted
+- source_type: local-implementation
+- scope: runops-target
+- relation: new
+- promotion_level: target-feature
+- source_feedback: `FB0004`
+- linked_records: `FB0004`, `E0004`, `H0004`, `D0003`
+
+## Source Observation
+
+Source: `harness-lab/records/feedback/FB0004-mcp-publication-export-manifest-inspect.md`
+
+# FB0004: MCP から publication export 一覧と manifest を inspect できるようにする
+
+## 概要
+
+GitHub issue: https://github.com/Nkzono99/runops/issues/67
+author: Nkzono99
+labels: なし
+created_at: 2026-05-14T01:53:06Z
+updated_at: 2026-05-14T01:53:06Z
+
+## Issue本文
+## 背景
+
+paperops の paper draft link registry から runops project を参照し、論文に使う export bundle を discovery / inspect したい。runops には `runo analyze export <run-or-survey> --paper <paper-id>` と `exports/papers/<paper-id>/<export-name>/manifest.json` が既にあるため、MCP 側では既存成果物を read/inspect する薄い入口が欲しい。
+
+## 提案
+
+- `runops.publication.exports.list` を追加する。
+  - 入力: `project_root`, optional `paper_id`, optional `limit`
+  - 出力: export id, paper id, export name, target kind, source run ids, created_at, manifest path, README path, warning count
+- `runops.publication.export.inspect` を追加する。
+  - 入力: `project_root`, `export` または `paper_id` + `name`
+  - 出力: `manifest.json` の要約、files[], source metadata, warnings
+- safety は read/inspect。file mutation は行わない。
+- `runo mcp tools --json`, `runo mcp check`, tests を更新する。
+
+## paperops からの利用イメージ
+
+paper draft 側は `refs/links.toml` の `kind = "runops_project"` link を解決し、MCP 経由で利用可能な export を列挙する。論文側に取り込む証拠は export manifest / files の参照に寄せる。
+
+## 受け入れ基準
+
+- export が無い project でも空配列で成功する。
+- `paper_id` filter が効く。
+- 壊れた manifest は warnings/errors として envelope に表現し、MCP protocol error にしない。
+- docs/mcp.md に tool が追記される。
+
+## 再現
+
+送信元フィードバックバンドルを参照してください。
+
+## 期待する上流変更
+
+送信元フィードバックバンドルを参照してください。
+
+## Target Capability
+
+- capability: mcp_publication_export_inspection
+- failure_class: missing_publication_export_manifest_inspect
+
+## Investigation
+
+- 2026-05-15T04:08:36+09:00 [implementation-sync] PR #72 implemented read-only MCP publication export inspection for FB0004: runops.publication.exports.list and runops.publication.export.inspect read existing exports/papers manifests, preserve empty-list behavior, and report broken manifests through envelope warnings/errors. (evidence: PR #72; issue #67; src/runops/mcp/tools.py; src/runops/mcp/server.py; docs/mcp.md; tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest)
+
+## Research Scans
+
+research scan はまだありません。
+
+
+## Evaluation
+
+### E0004: E0004: FB0004-mcp-publication-export-manifest-inspect を評価
+
+
+- source: `harness-lab/records/eval-cases/E0004-fb0004-mcp-publication-export-manifest-inspect.md`
+
+- capability: mcp_publication_export_inspection
+
+- failure_class: missing_publication_export_manifest_inspect
+
+- manual_eval_yml: `harness-lab/views/eval-results/E0004-manual-score.yml`
+- manual_eval_md: `harness-lab/views/eval-results/E0004-manual-score.md`
+- scores: impact=4, mechanism_clarity=5, evaluability=5, minimality=4, regression_risk=2, operator_burden=4, anti_theater=5, maintainability=4, privacy_sanitization_risk=5
+- notes: Implemented read-only MCP publication export tools: runops.publication.exports.list and runops.publication.export.inspect. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.
+
+
+## Hypotheses
+
+### H0004: H0004: E0004-fb0004-mcp-publication-export-manifest-inspect の仮説
+
+
+Source: `harness-lab/records/hypotheses/H0004-e0004-fb0004-mcp-publication-export-manifest-inspect.md`
+
+
+# H0004: E0004-fb0004-mcp-publication-export-manifest-inspect の仮説
+
+## 仮説
+
+The implemented read-only publication export MCP tools resolve FB0004 by exposing existing export manifests without creating or mutating files.
+
+## メカニズム
+
+The MCP layer registers list and inspect tools that scan exports/papers, parse manifest.json when present, and return structured Ops MCP envelopes; broken manifests become tool-level warnings/errors instead of protocol failures.
+
+## 最小実装
+
+Use the existing PR #72 implementation: runops.publication.exports.list, runops.publication.export.inspect, registry/server entries, docs/mcp.md, and focused MCP tool tests.
+
+## 代替案: 削除または統合
+
+Keep publication export discovery in CLI-only workflows, but paper-facing hosts would then need to inspect project files directly and duplicate manifest parsing.
+
+## 期待される利点
+
+Paper-facing agents can discover publication bundles through a read-only, typed interface and avoid mutating project state.
+
+## 想定される欠点
+
+The tool surface adds another MCP endpoint family that must stay aligned with publication manifest shape.
+
+## 評価計画
+
+Use E0004 manual score plus tests covering listing, inspect, empty exports, broken manifests, server registration, runo mcp tools --json, and runo mcp check.
+
+## 中止基準
+
+Reopen if the tools create files, hide broken manifests as protocol errors, omit empty export handling, or drift from documented manifest fields.
+
+
+## Evidence
+
+`harness-lab/views/eval-results/E0004-manual-score.md`
+
+## Guard
+
+- status: implemented
+- path: tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest; tests/test_mcp/test_server.py
+
+## Links
+
+- issue_url: https://github.com/Nkzono99/runops/issues/67
+
+## Open Questions And Next Action
+
+次の実装または評価ステップは、この dossier と紐づく正規化レコードを更新してから再生成してください。
+
+## Decision Log
+
+### D0003: D0003: adopted H0004
+
+
+Source: `harness-lab/records/decisions/D0003-adopted-h0004.md`
+
+
+# D0003: adopted H0004
+
+## 判断
+
+adopted
+
+## 理由
+
+PR #72 implemented the requested read-only publication export list/inspect MCP tools and issue #67 is closed.
+
+## 証拠
+
+E0004 manual score records passed validation; code evidence in src/runops/mcp/tools.py and src/runops/mcp/server.py; docs/mcp.md documents both tools; tests/test_mcp/test_tools.py covers valid and broken manifests; GitHub issue #67 is closed after PR #72.
+
+## 回帰リスク
+
+Low. The implementation is read-only and scoped to MCP inspection, with residual risk limited to publication manifest schema drift.
+
+## フォローアップ
+
+Keep runo mcp check and MCP registry/server tests as guards; revisit if publication manifest shape changes.
+
+## 回帰ガード
+
+tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest; tests/test_mcp/test_server.py

--- a/harness-lab/improvements/IMP0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
+++ b/harness-lab/improvements/IMP0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
@@ -1,0 +1,221 @@
+---
+id: IMP0005
+record_type: improvement_dossier
+created_at: '2026-05-15T04:09:19+09:00'
+updated_at: '2026-05-15T04:12:05+09:00'
+status: adopted
+source_type: local-implementation
+scope: runops-target
+maturity: adopted
+relation: new
+promotion_level: target-feature
+source_feedback: FB0005
+eval_cases:
+- E0005
+hypotheses:
+- H0005
+decisions:
+- D0004
+research_scans: []
+classification:
+  capability: mcp_analysis_result_inspection
+  failure_class: missing_paper_facing_analysis_artifact_inspect
+guard:
+  status: implemented
+  path: tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py
+investigation:
+- created_at: '2026-05-15T04:09:19+09:00'
+  kind: implementation-sync
+  summary: 'PR #72 implemented read-only MCP analysis inspection for FB0005: runops.analysis.artifacts, runops.survey.summary, and runops.analysis.plot_columns inspect existing artifact and summary files, apply limits, and report missing data through envelope warnings without generating analysis outputs.'
+  evidence_ref: 'PR #72; issue #68; src/runops/mcp/tools.py; src/runops/mcp/server.py; docs/mcp.md; tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py'
+links:
+  issue_url: https://github.com/Nkzono99/runops/issues/68
+---
+
+# IMP0005: FB0005: MCP から analysis artifacts / survey summary を paper 向けに inspect できるようにする
+
+## Status
+
+- status: adopted
+- maturity: adopted
+- source_type: local-implementation
+- scope: runops-target
+- relation: new
+- promotion_level: target-feature
+- source_feedback: `FB0005`
+- linked_records: `FB0005`, `E0005`, `H0005`, `D0004`
+
+## Source Observation
+
+Source: `harness-lab/records/feedback/FB0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md`
+
+# FB0005: MCP から analysis artifacts / survey summary を paper 向けに inspect できるようにする
+
+## 概要
+
+GitHub issue: https://github.com/Nkzono99/runops/issues/68
+author: Nkzono99
+labels: なし
+created_at: 2026-05-14T01:53:14Z
+updated_at: 2026-05-14T01:53:14Z
+
+## Issue本文
+## 背景
+
+paperops の draft から runops project を link したとき、論文に使う図・表・metric 候補を探索したい。現状 CLI には `runo analyze collect`, `plot`, `export` があり、`analysis/artifacts.toml` や `summary/survey_summary.json` もあるが、MCP から paper-facing に探索する入口がまだない。
+
+## 提案
+
+- `runops.analysis.artifacts` を追加する。
+  - 入力: `project_root`, `target` (run id / run dir / survey dir), optional `kind`, optional `limit`
+  - 出力: artifacts.toml 由来の artifact rows、absolute/relative path、run_id、caption/title/status
+- `runops.survey.summary` を追加する。
+  - 入力: `project_root`, `survey`, optional `include_runs`, optional `limit`
+  - 出力: `summary/survey_summary.json` の要約、state/readiness counts、numeric_stats、readiness_issues
+- 可能なら `runops.analysis.plot_columns` も追加する。
+  - `runo analyze plot --list-columns` 相当を structured data として返す。
+- safety は read/inspect。collect/plot のような生成を伴う処理は初期 scope から外すか、別途 plan/write tool に分ける。
+
+## paperops からの利用イメージ
+
+paper draft 側で `refs/links.toml` の runops link を選び、MCP で図表候補を見て、必要なら runops 側で export bundle を作る。draft には生 path ではなく export manifest または curated artifact metadata を残す。
+
+## 受け入れ基準
+
+- run と survey の両方を扱える。
+- missing artifacts / missing summaries は envelope の warnings に出る。
+- large result は `limit` で抑制できる。
+- docs/mcp.md と tests が更新される。
+
+## 再現
+
+送信元フィードバックバンドルを参照してください。
+
+## 期待する上流変更
+
+送信元フィードバックバンドルを参照してください。
+
+## Target Capability
+
+- capability: mcp_analysis_result_inspection
+- failure_class: missing_paper_facing_analysis_artifact_inspect
+
+## Investigation
+
+- 2026-05-15T04:09:19+09:00 [implementation-sync] PR #72 implemented read-only MCP analysis inspection for FB0005: runops.analysis.artifacts, runops.survey.summary, and runops.analysis.plot_columns inspect existing artifact and summary files, apply limits, and report missing data through envelope warnings without generating analysis outputs. (evidence: PR #72; issue #68; src/runops/mcp/tools.py; src/runops/mcp/server.py; docs/mcp.md; tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py)
+
+## Research Scans
+
+research scan はまだありません。
+
+
+## Evaluation
+
+### E0005: E0005: FB0005-mcp-analysis-artifacts-survey-summary-paper-inspect を評価
+
+
+- source: `harness-lab/records/eval-cases/E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md`
+
+- capability: mcp_analysis_result_inspection
+
+- failure_class: missing_paper_facing_analysis_artifact_inspect
+
+- manual_eval_yml: `harness-lab/views/eval-results/E0005-manual-score.yml`
+- manual_eval_md: `harness-lab/views/eval-results/E0005-manual-score.md`
+- scores: impact=4, mechanism_clarity=5, evaluability=5, minimality=4, regression_risk=2, operator_burden=4, anti_theater=5, maintainability=4, privacy_sanitization_risk=5
+- notes: Implemented read-only MCP analysis tools: runops.analysis.artifacts, runops.survey.summary, and runops.analysis.plot_columns. They inspect existing artifacts/summary files and report missing data through envelopes without collecting or plotting. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.
+
+
+## Hypotheses
+
+### H0005: H0005: E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect の仮説
+
+
+Source: `harness-lab/records/hypotheses/H0005-e0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md`
+
+
+# H0005: E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect の仮説
+
+## 仮説
+
+The implemented read-only MCP analysis tools resolve FB0005 by exposing existing analysis artifacts, survey summaries, and plot columns to paper-facing hosts without collecting or plotting new outputs.
+
+## メカニズム
+
+The MCP layer reads analysis/artifacts.toml or summary/artifacts.toml, summary/survey_summary.json, and aggregate columns into structured envelopes; missing files and clipped results are represented as warnings instead of filesystem mutation.
+
+## 最小実装
+
+Use the PR #72 implementation for runops.analysis.artifacts, runops.survey.summary, runops.analysis.plot_columns, registry/server entries, docs/mcp.md, and MCP tests.
+
+## 代替案: 削除または統合
+
+Keep figure/table discovery in CLI-only or ad hoc file inspection workflows, which would force paper-facing hosts to duplicate runops artifact parsing.
+
+## 期待される利点
+
+Paper-facing agents can inspect figure, table, metric, and survey summary candidates safely before requesting curated exports.
+
+## 想定される欠点
+
+The MCP read model must stay aligned with analysis artifact and survey summary file formats.
+
+## 評価計画
+
+Use E0005 manual score plus tests for run/survey artifact reads, missing summary warnings, limit clipping, server registration, runo mcp tools --json, and runo mcp check.
+
+## 中止基準
+
+Reopen if these tools generate artifacts, mutate project files, ignore limits, or return missing data as MCP protocol errors.
+
+
+## Evidence
+
+`harness-lab/views/eval-results/E0005-manual-score.md`
+
+## Guard
+
+- status: implemented
+- path: tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py
+
+## Links
+
+- issue_url: https://github.com/Nkzono99/runops/issues/68
+
+## Open Questions And Next Action
+
+次の実装または評価ステップは、この dossier と紐づく正規化レコードを更新してから再生成してください。
+
+## Decision Log
+
+### D0004: D0004: adopted H0005
+
+
+Source: `harness-lab/records/decisions/D0004-adopted-h0005.md`
+
+
+# D0004: adopted H0005
+
+## 判断
+
+adopted
+
+## 理由
+
+PR #72 implemented the requested read-only analysis artifact and survey summary MCP tools and issue #68 is closed.
+
+## 証拠
+
+E0005 manual score records passed validation; code evidence in src/runops/mcp/tools.py and src/runops/mcp/server.py; docs/mcp.md documents the tools; tests/test_mcp/test_tools.py and tests/test_mcp/test_server.py cover the MCP read surfaces; GitHub issue #68 is closed after PR #72.
+
+## 回帰リスク
+
+Low to medium. The implementation is read-only, but it depends on analysis artifact and survey summary schema stability.
+
+## フォローアップ
+
+Keep MCP tests and runo mcp check as guards; update docs/tests when analysis artifact or survey summary formats change.
+
+## 回帰ガード
+
+tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py

--- a/harness-lab/improvements/IMP0006-fb0006-paper-draft-runops-research-agenda-contract.md
+++ b/harness-lab/improvements/IMP0006-fb0006-paper-draft-runops-research-agenda-contract.md
@@ -1,0 +1,217 @@
+---
+id: IMP0006
+record_type: improvement_dossier
+created_at: '2026-05-15T04:10:01+09:00'
+updated_at: '2026-05-15T04:12:06+09:00'
+status: adopted
+source_type: local-implementation
+scope: runops-target
+maturity: adopted
+relation: new
+promotion_level: target-feature
+source_feedback: FB0006
+eval_cases:
+- E0006
+hypotheses:
+- H0006
+decisions:
+- D0005
+research_scans: []
+classification:
+  capability: paper_request_contract
+  failure_class: missing_paper_to_runops_request_contract
+guard:
+  status: implemented
+  path: tests/test_mcp/test_tools.py; tests/test_mcp/test_server.py; tests/test_cli/test_init.py
+investigation:
+- created_at: '2026-05-15T04:10:01+09:00'
+  kind: implementation-sync
+  summary: 'PR #72 implemented the paper request contract requested by FB0006 with docs, schema/template support, and read/plan MCP tools; PR #73 fixed the empty paper request queue regression so missing or empty research/paper_requests.toml returns an empty read model instead of failing.'
+  evidence_ref: 'PR #72; PR #73; issue #69; docs/paper-requests.md; docs/mcp.md; src/runops/templates/project/research/paper_requests.toml; src/runops/mcp/tools.py; tests/test_mcp/test_tools.py; tests/test_cli/test_init.py'
+links:
+  issue_url: https://github.com/Nkzono99/runops/issues/69
+---
+
+# IMP0006: FB0006: paper draft からの追加解析・追加実験要望を runops research agenda に取り込む contract を設計する
+
+## Status
+
+- status: adopted
+- maturity: adopted
+- source_type: local-implementation
+- scope: runops-target
+- relation: new
+- promotion_level: target-feature
+- source_feedback: `FB0006`
+- linked_records: `FB0006`, `E0006`, `H0006`, `D0005`
+
+## Source Observation
+
+Source: `harness-lab/records/feedback/FB0006-paper-draft-runops-research-agenda-contract.md`
+
+# FB0006: paper draft からの追加解析・追加実験要望を runops research agenda に取り込む contract を設計する
+
+## 概要
+
+GitHub issue: https://github.com/Nkzono99/runops/issues/69
+author: Nkzono99
+labels: なし
+created_at: 2026-05-14T01:53:22Z
+updated_at: 2026-05-14T01:53:22Z
+
+## Issue本文
+## 背景
+
+paperops の執筆中に、結果セクションや図表設計から「この追加解析が必要」「この条件の run を追加したい」「この export は placeholder 扱い」などの需要が出る。これを runops project 側の research agenda / case / survey design に戻すための軽い contract が欲しい。
+
+## 提案
+
+- paper-facing request schema を設計する。
+  - 例: `analysis_request`, `figure_request`, `experiment_request`, `evidence_gap`, `export_request`
+  - fields: id, title, paper_context, desired_artifact, source_link, related_runs/surveys, priority, status
+- runops 側で import 先を決める。
+  - 候補: `research/agenda.md`, `research/proposals/`, または structured TOML/JSONL
+- MCP または CLI に read/plan entrypoint を追加するか検討する。
+  - 初期は read/plan のみでよい。
+  - 実際の run creation / survey expansion は既存 `create-run` / `setup-campaign` flow に委ねる。
+- paperops の link registry から runops project link と request を対応づけられるようにする。
+
+## 受け入れ基準
+
+- request schema の docs と例がある。
+- paperops 側の `refs/links.toml` / notes から参照できる stable id を持つ。
+- runops project 内で未処理・処理中・完了を追える。
+- 追加実験の実行そのものは明示操作に残し、MCP 経由で勝手に submit しない。
+
+## 再現
+
+送信元フィードバックバンドルを参照してください。
+
+## 期待する上流変更
+
+送信元フィードバックバンドルを参照してください。
+
+## Target Capability
+
+- capability: paper_request_contract
+- failure_class: missing_paper_to_runops_request_contract
+
+## Investigation
+
+- 2026-05-15T04:10:01+09:00 [implementation-sync] PR #72 implemented the paper request contract requested by FB0006 with docs, schema/template support, and read/plan MCP tools; PR #73 fixed the empty paper request queue regression so missing or empty research/paper_requests.toml returns an empty read model instead of failing. (evidence: PR #72; PR #73; issue #69; docs/paper-requests.md; docs/mcp.md; src/runops/templates/project/research/paper_requests.toml; src/runops/mcp/tools.py; tests/test_mcp/test_tools.py; tests/test_cli/test_init.py)
+
+## Research Scans
+
+research scan はまだありません。
+
+
+## Evaluation
+
+### E0006: E0006: FB0006-paper-draft-runops-research-agenda-contract を評価
+
+
+- source: `harness-lab/records/eval-cases/E0006-fb0006-paper-draft-runops-research-agenda-contract.md`
+
+- capability: paper_request_contract
+
+- failure_class: missing_paper_to_runops_request_contract
+
+- manual_eval_yml: `harness-lab/views/eval-results/E0006-manual-score.yml`
+- manual_eval_md: `harness-lab/views/eval-results/E0006-manual-score.md`
+- scores: impact=3, mechanism_clarity=5, evaluability=5, minimality=4, regression_risk=2, operator_burden=4, anti_theater=5, maintainability=4, privacy_sanitization_risk=5
+- notes: Implemented the paper request contract with docs, schema, scaffold template, and read/plan MCP tools: runops.paper.requests.list and runops.paper.request.plan. The tools do not mutate files or submit jobs. Validation passed: ruff check src/ tests/, mypy src/, pytest, pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80, and runo mcp check.
+
+
+## Hypotheses
+
+### H0006: H0006: E0006-fb0006-paper-draft-runops-research-agenda-contract の仮説
+
+
+Source: `harness-lab/records/hypotheses/H0006-e0006-fb0006-paper-draft-runops-research-agenda-contract.md`
+
+
+# H0006: E0006-fb0006-paper-draft-runops-research-agenda-contract の仮説
+
+## 仮説
+
+The implemented paper request contract resolves FB0006 by giving paper drafts a stable read/plan interface back into runops research agenda work without triggering run creation, survey expansion, or job submission.
+
+## メカニズム
+
+A documented paper request schema and template define stable ids, request kinds, priorities, statuses, source links, and related run/survey references; MCP tools list requests and produce plans that point back to research/agenda.md or proposals while remaining non-mutating.
+
+## 最小実装
+
+Use the PR #72 implementation for docs/paper-requests.md, project scaffold template, runops.paper.requests.list, runops.paper.request.plan, docs/mcp.md, and focused tests, plus PR #73's empty queue guard.
+
+## 代替案: 削除または統合
+
+Keep paper-to-runops follow-up as prose notes only, but then additional analysis and experiment needs lack stable ids or a safe read/plan API.
+
+## 期待される利点
+
+Paper-facing agents can track additional analysis, figure, evidence-gap, export, and experiment requests without bypassing human-gated runops workflows.
+
+## 想定される欠点
+
+This creates another project-side planning artifact that must not become an implicit execution queue.
+
+## 評価計画
+
+Use E0006 manual score plus tests for request listing, planning, empty queues, scaffold output, MCP server registration, runo mcp tools --json, and runo mcp check.
+
+## 中止基準
+
+Reopen if request planning mutates files, submits jobs, lacks stable ids, or treats experiment requests as automatic execution.
+
+
+## Evidence
+
+`harness-lab/views/eval-results/E0006-manual-score.md`
+
+## Guard
+
+- status: implemented
+- path: tests/test_mcp/test_tools.py; tests/test_mcp/test_server.py; tests/test_cli/test_init.py
+
+## Links
+
+- issue_url: https://github.com/Nkzono99/runops/issues/69
+
+## Open Questions And Next Action
+
+次の実装または評価ステップは、この dossier と紐づく正規化レコードを更新してから再生成してください。
+
+## Decision Log
+
+### D0005: D0005: adopted H0006
+
+
+Source: `harness-lab/records/decisions/D0005-adopted-h0006.md`
+
+
+# D0005: adopted H0006
+
+## 判断
+
+adopted
+
+## 理由
+
+PR #72 implemented the paper request contract and read/plan MCP tools, PR #73 fixed empty request queues, and issue #69 is closed.
+
+## 証拠
+
+E0006 manual score records passed validation; docs/paper-requests.md and docs/mcp.md document the contract; src/runops/mcp/tools.py exposes runops.paper.requests.list and runops.paper.request.plan; tests cover the request read/plan behavior and empty queue guard; GitHub issue #69 is closed after PR #72 and PR #73.
+
+## 回帰リスク
+
+Low to medium. The tools are read/plan only, but the planning contract must remain clearly separated from run creation, survey expansion, and Slurm submission.
+
+## フォローアップ
+
+Keep paper request tests, MCP registry checks, and docs aligned; do not add execution semantics to paper request MCP tools without a separate gated design.
+
+## 回帰ガード
+
+tests/test_mcp/test_tools.py; tests/test_mcp/test_server.py; tests/test_cli/test_init.py

--- a/harness-lab/records/decisions/D0003-adopted-h0004.md
+++ b/harness-lab/records/decisions/D0003-adopted-h0004.md
@@ -1,0 +1,36 @@
+---
+id: D0003
+record_type: decision
+created_at: '2026-05-15T04:09:00+09:00'
+status: adopted
+source: H0004
+evidence:
+  summary: 'E0004 manual score records passed validation; code evidence in src/runops/mcp/tools.py and src/runops/mcp/server.py; docs/mcp.md documents both tools; tests/test_mcp/test_tools.py covers valid and broken manifests; GitHub issue #67 is closed after PR #72.'
+  guard_path: tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest; tests/test_mcp/test_server.py
+---
+
+# D0003: adopted H0004
+
+## 判断
+
+adopted
+
+## 理由
+
+PR #72 implemented the requested read-only publication export list/inspect MCP tools and issue #67 is closed.
+
+## 証拠
+
+E0004 manual score records passed validation; code evidence in src/runops/mcp/tools.py and src/runops/mcp/server.py; docs/mcp.md documents both tools; tests/test_mcp/test_tools.py covers valid and broken manifests; GitHub issue #67 is closed after PR #72.
+
+## 回帰リスク
+
+Low. The implementation is read-only and scoped to MCP inspection, with residual risk limited to publication manifest schema drift.
+
+## フォローアップ
+
+Keep runo mcp check and MCP registry/server tests as guards; revisit if publication manifest shape changes.
+
+## 回帰ガード
+
+tests/test_mcp/test_tools.py::test_publication_exports_list_and_inspect_manifest; tests/test_mcp/test_tools.py::test_publication_exports_list_reports_broken_manifest; tests/test_mcp/test_server.py

--- a/harness-lab/records/decisions/D0004-adopted-h0005.md
+++ b/harness-lab/records/decisions/D0004-adopted-h0005.md
@@ -1,0 +1,36 @@
+---
+id: D0004
+record_type: decision
+created_at: '2026-05-15T04:09:40+09:00'
+status: adopted
+source: H0005
+evidence:
+  summary: 'E0005 manual score records passed validation; code evidence in src/runops/mcp/tools.py and src/runops/mcp/server.py; docs/mcp.md documents the tools; tests/test_mcp/test_tools.py and tests/test_mcp/test_server.py cover the MCP read surfaces; GitHub issue #68 is closed after PR #72.'
+  guard_path: tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py
+---
+
+# D0004: adopted H0005
+
+## 判断
+
+adopted
+
+## 理由
+
+PR #72 implemented the requested read-only analysis artifact and survey summary MCP tools and issue #68 is closed.
+
+## 証拠
+
+E0005 manual score records passed validation; code evidence in src/runops/mcp/tools.py and src/runops/mcp/server.py; docs/mcp.md documents the tools; tests/test_mcp/test_tools.py and tests/test_mcp/test_server.py cover the MCP read surfaces; GitHub issue #68 is closed after PR #72.
+
+## 回帰リスク
+
+Low to medium. The implementation is read-only, but it depends on analysis artifact and survey summary schema stability.
+
+## フォローアップ
+
+Keep MCP tests and runo mcp check as guards; update docs/tests when analysis artifact or survey summary formats change.
+
+## 回帰ガード
+
+tests/test_mcp/test_tools.py::test_survey_summary_and_plot_columns_read_existing_summary; tests/test_mcp/test_server.py

--- a/harness-lab/records/decisions/D0005-adopted-h0006.md
+++ b/harness-lab/records/decisions/D0005-adopted-h0006.md
@@ -1,0 +1,36 @@
+---
+id: D0005
+record_type: decision
+created_at: '2026-05-15T04:10:28+09:00'
+status: adopted
+source: H0006
+evidence:
+  summary: 'E0006 manual score records passed validation; docs/paper-requests.md and docs/mcp.md document the contract; src/runops/mcp/tools.py exposes runops.paper.requests.list and runops.paper.request.plan; tests cover the request read/plan behavior and empty queue guard; GitHub issue #69 is closed after PR #72 and PR #73.'
+  guard_path: tests/test_mcp/test_tools.py; tests/test_mcp/test_server.py; tests/test_cli/test_init.py
+---
+
+# D0005: adopted H0006
+
+## 判断
+
+adopted
+
+## 理由
+
+PR #72 implemented the paper request contract and read/plan MCP tools, PR #73 fixed empty request queues, and issue #69 is closed.
+
+## 証拠
+
+E0006 manual score records passed validation; docs/paper-requests.md and docs/mcp.md document the contract; src/runops/mcp/tools.py exposes runops.paper.requests.list and runops.paper.request.plan; tests cover the request read/plan behavior and empty queue guard; GitHub issue #69 is closed after PR #72 and PR #73.
+
+## 回帰リスク
+
+Low to medium. The tools are read/plan only, but the planning contract must remain clearly separated from run creation, survey expansion, and Slurm submission.
+
+## フォローアップ
+
+Keep paper request tests, MCP registry checks, and docs aligned; do not add execution semantics to paper request MCP tools without a separate gated design.
+
+## 回帰ガード
+
+tests/test_mcp/test_tools.py; tests/test_mcp/test_server.py; tests/test_cli/test_init.py

--- a/harness-lab/records/eval-cases/E0004-fb0004-mcp-publication-export-manifest-inspect.md
+++ b/harness-lab/records/eval-cases/E0004-fb0004-mcp-publication-export-manifest-inspect.md
@@ -3,8 +3,8 @@ id: E0004
 record_type: eval_case
 created_at: '2026-05-14T11:15:02+09:00'
 status: active
-capability: unclassified
-failure_class: unclassified
+capability: mcp_publication_export_inspection
+failure_class: missing_publication_export_manifest_inspect
 source_feedback: FB0004
 ---
 
@@ -22,7 +22,7 @@ updated_at: 2026-05-14T01:53:06Z
 
 ## タスク
 
-`unclassified` の `unclassified` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
+`mcp_publication_export_inspection` の `missing_publication_export_manifest_inspect` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
 
 送信元フィードバックバンドルを参照してください。
 
@@ -32,14 +32,14 @@ updated_at: 2026-05-14T01:53:06Z
 
 ## 合格基準
 
-- `unclassified` の再現条件が検出または防止される。
+- `missing_publication_export_manifest_inspect` の再現条件が検出または防止される。
 - 提案または実装される変更が source feedback の期待変更に対応している。
 - `hops eval --case E0004 --manual` の score と notes で採用判断に必要な証拠を説明できる。
 - 非公開プロジェクト詳細を追加で要求しない。
 
 ## 不合格基準
 
-- `unclassified` の再現条件を見逃す。
+- `missing_publication_export_manifest_inspect` の再現条件を見逃す。
 - source feedback の期待変更と無関係な改善案になる。
 - 評価が yml score へ記録されず、採用判断の証拠として追えない。
 - 再現または判断に非公開文脈が必要になる。

--- a/harness-lab/records/eval-cases/E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
+++ b/harness-lab/records/eval-cases/E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
@@ -3,8 +3,8 @@ id: E0005
 record_type: eval_case
 created_at: '2026-05-14T11:15:05+09:00'
 status: active
-capability: unclassified
-failure_class: unclassified
+capability: mcp_analysis_result_inspection
+failure_class: missing_paper_facing_analysis_artifact_inspect
 source_feedback: FB0005
 ---
 
@@ -22,7 +22,7 @@ updated_at: 2026-05-14T01:53:14Z
 
 ## タスク
 
-`unclassified` の `unclassified` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
+`mcp_analysis_result_inspection` の `missing_paper_facing_analysis_artifact_inspect` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
 
 送信元フィードバックバンドルを参照してください。
 
@@ -32,14 +32,14 @@ updated_at: 2026-05-14T01:53:14Z
 
 ## 合格基準
 
-- `unclassified` の再現条件が検出または防止される。
+- `missing_paper_facing_analysis_artifact_inspect` の再現条件が検出または防止される。
 - 提案または実装される変更が source feedback の期待変更に対応している。
 - `hops eval --case E0005 --manual` の score と notes で採用判断に必要な証拠を説明できる。
 - 非公開プロジェクト詳細を追加で要求しない。
 
 ## 不合格基準
 
-- `unclassified` の再現条件を見逃す。
+- `missing_paper_facing_analysis_artifact_inspect` の再現条件を見逃す。
 - source feedback の期待変更と無関係な改善案になる。
 - 評価が yml score へ記録されず、採用判断の証拠として追えない。
 - 再現または判断に非公開文脈が必要になる。

--- a/harness-lab/records/eval-cases/E0006-fb0006-paper-draft-runops-research-agenda-contract.md
+++ b/harness-lab/records/eval-cases/E0006-fb0006-paper-draft-runops-research-agenda-contract.md
@@ -3,8 +3,8 @@ id: E0006
 record_type: eval_case
 created_at: '2026-05-14T11:15:09+09:00'
 status: active
-capability: unclassified
-failure_class: unclassified
+capability: paper_request_contract
+failure_class: missing_paper_to_runops_request_contract
 source_feedback: FB0006
 ---
 
@@ -22,7 +22,7 @@ updated_at: 2026-05-14T01:53:22Z
 
 ## タスク
 
-`unclassified` の `unclassified` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
+`paper_request_contract` の `missing_paper_to_runops_request_contract` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
 
 送信元フィードバックバンドルを参照してください。
 
@@ -32,14 +32,14 @@ updated_at: 2026-05-14T01:53:22Z
 
 ## 合格基準
 
-- `unclassified` の再現条件が検出または防止される。
+- `missing_paper_to_runops_request_contract` の再現条件が検出または防止される。
 - 提案または実装される変更が source feedback の期待変更に対応している。
 - `hops eval --case E0006 --manual` の score と notes で採用判断に必要な証拠を説明できる。
 - 非公開プロジェクト詳細を追加で要求しない。
 
 ## 不合格基準
 
-- `unclassified` の再現条件を見逃す。
+- `missing_paper_to_runops_request_contract` の再現条件を見逃す。
 - source feedback の期待変更と無関係な改善案になる。
 - 評価が yml score へ記録されず、採用判断の証拠として追えない。
 - 再現または判断に非公開文脈が必要になる。

--- a/harness-lab/records/feedback/FB0004-mcp-publication-export-manifest-inspect.md
+++ b/harness-lab/records/feedback/FB0004-mcp-publication-export-manifest-inspect.md
@@ -19,11 +19,15 @@ source:
     updated_at: '2026-05-14T01:53:06Z'
     comments: []
 classification:
-  failure_class: unclassified
-  capability: unclassified
+  failure_class: missing_publication_export_manifest_inspect
+  capability: mcp_publication_export_inspection
 links:
   eval_case:
   issue_url: https://github.com/Nkzono99/runops/issues/67
+disposition:
+  type: protocol-candidate
+  target:
+  status: draft
 ---
 
 # FB0004: MCP から publication export 一覧と manifest を inspect できるようにする

--- a/harness-lab/records/feedback/FB0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
+++ b/harness-lab/records/feedback/FB0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
@@ -19,11 +19,15 @@ source:
     updated_at: '2026-05-14T01:53:14Z'
     comments: []
 classification:
-  failure_class: unclassified
-  capability: unclassified
+  failure_class: missing_paper_facing_analysis_artifact_inspect
+  capability: mcp_analysis_result_inspection
 links:
   eval_case:
   issue_url: https://github.com/Nkzono99/runops/issues/68
+disposition:
+  type: target-upstream-candidate
+  target:
+  status: draft
 ---
 
 # FB0005: MCP から analysis artifacts / survey summary を paper 向けに inspect できるようにする

--- a/harness-lab/records/feedback/FB0006-paper-draft-runops-research-agenda-contract.md
+++ b/harness-lab/records/feedback/FB0006-paper-draft-runops-research-agenda-contract.md
@@ -19,11 +19,15 @@ source:
     updated_at: '2026-05-14T01:53:22Z'
     comments: []
 classification:
-  failure_class: unclassified
-  capability: unclassified
+  failure_class: missing_paper_to_runops_request_contract
+  capability: paper_request_contract
 links:
   eval_case:
   issue_url: https://github.com/Nkzono99/runops/issues/69
+disposition:
+  type: meta-harness-candidate
+  target:
+  status: draft
 ---
 
 # FB0006: paper draft からの追加解析・追加実験要望を runops research agenda に取り込む contract を設計する

--- a/harness-lab/records/hypotheses/H0004-e0004-fb0004-mcp-publication-export-manifest-inspect.md
+++ b/harness-lab/records/hypotheses/H0004-e0004-fb0004-mcp-publication-export-manifest-inspect.md
@@ -1,0 +1,42 @@
+---
+id: H0004
+record_type: hypothesis
+created_at: '2026-05-15T04:08:49+09:00'
+status: proposed
+target_capability: mcp_publication_export_inspection
+source_eval_case: E0004
+---
+
+# H0004: E0004-fb0004-mcp-publication-export-manifest-inspect の仮説
+
+## 仮説
+
+The implemented read-only publication export MCP tools resolve FB0004 by exposing existing export manifests without creating or mutating files.
+
+## メカニズム
+
+The MCP layer registers list and inspect tools that scan exports/papers, parse manifest.json when present, and return structured Ops MCP envelopes; broken manifests become tool-level warnings/errors instead of protocol failures.
+
+## 最小実装
+
+Use the existing PR #72 implementation: runops.publication.exports.list, runops.publication.export.inspect, registry/server entries, docs/mcp.md, and focused MCP tool tests.
+
+## 代替案: 削除または統合
+
+Keep publication export discovery in CLI-only workflows, but paper-facing hosts would then need to inspect project files directly and duplicate manifest parsing.
+
+## 期待される利点
+
+Paper-facing agents can discover publication bundles through a read-only, typed interface and avoid mutating project state.
+
+## 想定される欠点
+
+The tool surface adds another MCP endpoint family that must stay aligned with publication manifest shape.
+
+## 評価計画
+
+Use E0004 manual score plus tests covering listing, inspect, empty exports, broken manifests, server registration, runo mcp tools --json, and runo mcp check.
+
+## 中止基準
+
+Reopen if the tools create files, hide broken manifests as protocol errors, omit empty export handling, or drift from documented manifest fields.

--- a/harness-lab/records/hypotheses/H0005-e0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
+++ b/harness-lab/records/hypotheses/H0005-e0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect.md
@@ -1,0 +1,42 @@
+---
+id: H0005
+record_type: hypothesis
+created_at: '2026-05-15T04:09:30+09:00'
+status: proposed
+target_capability: mcp_analysis_result_inspection
+source_eval_case: E0005
+---
+
+# H0005: E0005-fb0005-mcp-analysis-artifacts-survey-summary-paper-inspect の仮説
+
+## 仮説
+
+The implemented read-only MCP analysis tools resolve FB0005 by exposing existing analysis artifacts, survey summaries, and plot columns to paper-facing hosts without collecting or plotting new outputs.
+
+## メカニズム
+
+The MCP layer reads analysis/artifacts.toml or summary/artifacts.toml, summary/survey_summary.json, and aggregate columns into structured envelopes; missing files and clipped results are represented as warnings instead of filesystem mutation.
+
+## 最小実装
+
+Use the PR #72 implementation for runops.analysis.artifacts, runops.survey.summary, runops.analysis.plot_columns, registry/server entries, docs/mcp.md, and MCP tests.
+
+## 代替案: 削除または統合
+
+Keep figure/table discovery in CLI-only or ad hoc file inspection workflows, which would force paper-facing hosts to duplicate runops artifact parsing.
+
+## 期待される利点
+
+Paper-facing agents can inspect figure, table, metric, and survey summary candidates safely before requesting curated exports.
+
+## 想定される欠点
+
+The MCP read model must stay aligned with analysis artifact and survey summary file formats.
+
+## 評価計画
+
+Use E0005 manual score plus tests for run/survey artifact reads, missing summary warnings, limit clipping, server registration, runo mcp tools --json, and runo mcp check.
+
+## 中止基準
+
+Reopen if these tools generate artifacts, mutate project files, ignore limits, or return missing data as MCP protocol errors.

--- a/harness-lab/records/hypotheses/H0006-e0006-fb0006-paper-draft-runops-research-agenda-contract.md
+++ b/harness-lab/records/hypotheses/H0006-e0006-fb0006-paper-draft-runops-research-agenda-contract.md
@@ -1,0 +1,42 @@
+---
+id: H0006
+record_type: hypothesis
+created_at: '2026-05-15T04:10:15+09:00'
+status: proposed
+target_capability: paper_request_contract
+source_eval_case: E0006
+---
+
+# H0006: E0006-fb0006-paper-draft-runops-research-agenda-contract の仮説
+
+## 仮説
+
+The implemented paper request contract resolves FB0006 by giving paper drafts a stable read/plan interface back into runops research agenda work without triggering run creation, survey expansion, or job submission.
+
+## メカニズム
+
+A documented paper request schema and template define stable ids, request kinds, priorities, statuses, source links, and related run/survey references; MCP tools list requests and produce plans that point back to research/agenda.md or proposals while remaining non-mutating.
+
+## 最小実装
+
+Use the PR #72 implementation for docs/paper-requests.md, project scaffold template, runops.paper.requests.list, runops.paper.request.plan, docs/mcp.md, and focused tests, plus PR #73's empty queue guard.
+
+## 代替案: 削除または統合
+
+Keep paper-to-runops follow-up as prose notes only, but then additional analysis and experiment needs lack stable ids or a safe read/plan API.
+
+## 期待される利点
+
+Paper-facing agents can track additional analysis, figure, evidence-gap, export, and experiment requests without bypassing human-gated runops workflows.
+
+## 想定される欠点
+
+This creates another project-side planning artifact that must not become an implicit execution queue.
+
+## 評価計画
+
+Use E0006 manual score plus tests for request listing, planning, empty queues, scaffold output, MCP server registration, runo mcp tools --json, and runo mcp check.
+
+## 中止基準
+
+Reopen if request planning mutates files, submits jobs, lacks stable ids, or treats experiment requests as automatic execution.

--- a/harness-lab/views/eval-results/E0004-manual-score.md
+++ b/harness-lab/views/eval-results/E0004-manual-score.md
@@ -21,6 +21,6 @@ Implemented read-only MCP publication export tools: runops.publication.exports.l
 
 ## 評価ケース
 
-- capability: unclassified
-- failure_class: unclassified
+- capability: mcp_publication_export_inspection
+- failure_class: missing_publication_export_manifest_inspect
 - source_feedback: FB0004

--- a/harness-lab/views/eval-results/E0005-manual-score.md
+++ b/harness-lab/views/eval-results/E0005-manual-score.md
@@ -21,6 +21,6 @@ Implemented read-only MCP analysis tools: runops.analysis.artifacts, runops.surv
 
 ## 評価ケース
 
-- capability: unclassified
-- failure_class: unclassified
+- capability: mcp_analysis_result_inspection
+- failure_class: missing_paper_facing_analysis_artifact_inspect
 - source_feedback: FB0005

--- a/harness-lab/views/eval-results/E0006-manual-score.md
+++ b/harness-lab/views/eval-results/E0006-manual-score.md
@@ -21,6 +21,6 @@ Implemented the paper request contract with docs, schema, scaffold template, and
 
 ## 評価ケース
 
-- capability: unclassified
-- failure_class: unclassified
+- capability: paper_request_contract
+- failure_class: missing_paper_to_runops_request_contract
 - source_feedback: FB0006

--- a/harness-lab/views/imported-feedback.md
+++ b/harness-lab/views/imported-feedback.md
@@ -4,6 +4,6 @@
 - `FB0001` triaged harness_improvement_capture missing_proactive_harness_lab_capture
 - `FB0002` triaged lab_cli_error_handling expected_user_error_traceback
 - `FB0003` triaged role_scoped_agent_bridge project_feedback_interface_too_broad
-- `FB0004` triaged unclassified unclassified
-- `FB0005` triaged unclassified unclassified
-- `FB0006` triaged unclassified unclassified
+- `FB0004` triaged mcp_publication_export_inspection missing_publication_export_manifest_inspect
+- `FB0005` triaged mcp_analysis_result_inspection missing_paper_facing_analysis_artifact_inspect
+- `FB0006` triaged paper_request_contract missing_paper_to_runops_request_contract

--- a/harness-lab/views/improvements.md
+++ b/harness-lab/views/improvements.md
@@ -4,3 +4,6 @@
 - `IMP0001` active maturity=investigated scope=harnessops-core promotion=target-lab-case source=FB0001 harness_improvement_capture missing_proactive_harness_lab_capture
 - `IMP0002` needs-more-evidence maturity=investigated scope=harnessops-core promotion=core-bugfix source=FB0002 lab_cli_error_handling expected_user_error_traceback
 - `IMP0003` adopted maturity=adopted scope=harnessops-core promotion=target-lab-case source=FB0003 role_scoped_agent_bridge project_feedback_interface_too_broad
+- `IMP0004` adopted maturity=adopted scope=runops-target promotion=target-feature source=FB0004 mcp_publication_export_inspection missing_publication_export_manifest_inspect
+- `IMP0005` adopted maturity=adopted scope=runops-target promotion=target-feature source=FB0005 mcp_analysis_result_inspection missing_paper_facing_analysis_artifact_inspect
+- `IMP0006` adopted maturity=adopted scope=runops-target promotion=target-feature source=FB0006 paper_request_contract missing_paper_to_runops_request_contract


### PR DESCRIPTION
## Summary
- Reconciles FB0004-FB0006 with adopted IMP0004-IMP0006 dossiers
- Adds implementation-sync evidence, H0004-H0006 hypotheses, and D0003-D0005 adoption decisions
- Updates lab classifications and generated HOPS views for paper-facing MCP work

## Validation
- uvx --from harnessops hops doctor --check-overlay --check-records
- uvx --from harnessops hops migrate --check
- uv run runo mcp check
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run mypy src/
- uv run pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80
