### PR TITLE
chore: release 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runops"
-version = "0.10.0"
+version = "0.11.0"
 description = "HPC simulation run management CLI tool for Slurm-based environments"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/runops/__init__.py
+++ b/src/runops/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
## 概要

runops 0.11.0 は、paperops 連携に向けて paper-facing MCP tool と paper request handoff を強化するリリースです。paper draft から runops project へ追加解析・図表・追加実験要望を戻す導線が、より安全に preview / validation できるようになりました。

## 主な追加機能

- publication export / analysis artifacts / survey summary を読む paper-facing MCP tool を追加しました。
- `runops.paper.request.draft` を追加し、paper request 候補の preview / validation と TOML snippet 生成に対応しました。
- HOPS GitHub Flow / issue triage / agent bridge を更新しました。

## 主な修正

- 空の `paper_requests.toml` を schema-valid な queue として扱うよう修正しました。
- duplicate `request_id` の draft が append 可能に見えないよう、`valid=false`、snippet なし、append next action なしに修正しました。

## 補足

- repo-local triage skill と旧 automation prompt を整理し、HOPS 側の triage / daily steward に統合しました。

## Validation

- `uv run ruff check src/ tests/`
- `uv run mypy src/`
- `uv run pytest tests/ -x -q`