### PR TITLE
chore: sync lockfile for 0.11.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,7 @@ wheels = [
 
 [[package]]
 name = "runops"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## 概要

0.11.0 release PR の merge 後に、`uv.lock` の editable package version が `0.11.0` へ同期された差分です。tag 作成前に lockfile も main と一致させます。

## Validation

- release PR #80 で `ruff check`, `mypy`, `pytest tests/ -x -q` 済み
- 差分は `uv.lock` の runops version 1 行のみ