### PR TITLE
Record lab classification backfill gap

### DIFF
--- a/.harnessops/lock.json
+++ b/.harnessops/lock.json
@@ -36,8 +36,8 @@
   "managed_files": {
     "harness-lab/README.md": "sha256:789a733220c9918b65f6d7afbddb13ccc2d842485cca9426bb8e5dc52c24a797",
     "harness-lab/views/backlog.md": "sha256:0ed4436872ad24f9c73737b7f84290306dc4baaf36154b7e36be521e985b791c",
-    "harness-lab/views/imported-feedback.md": "sha256:03f6a3ad485e5a0232421afd7c9e0519a3626e980a2cc0e5e3ce9c048afe0ca4",
-    "harness-lab/views/improvements.md": "sha256:ebda4260fe4d31b014b81ba7138339c93a0115c07e406ab447a7e92914d677b1",
+    "harness-lab/views/imported-feedback.md": "sha256:b8f02d55cdd9429be35eb3c44ff932e240804fdc5d98c813352b1357b507596d",
+    "harness-lab/views/improvements.md": "sha256:d49cf00f3280ef142b15ea3344c8e50713e376275cebb20eaae92dc69c9d8292",
     "harness-lab/views/research-scans.md": "sha256:6d61d712641e7eddc710614cf7bc59889c78e9532dc82666e4d82dadcc06cf7a",
     "harness-lab/views/score-trajectory.md": "sha256:a3d2f445609e5e9da0269ece3b10aff2414f3830bd185ad257d32ae19026b616"
   },

--- a/harness-lab/improvements/IMP0009-fb0009-adopted-lab-records-need-classification-backfill.md
+++ b/harness-lab/improvements/IMP0009-fb0009-adopted-lab-records-need-classification-backfill.md
@@ -1,0 +1,151 @@
+---
+id: IMP0009
+record_type: improvement_dossier
+created_at: '2026-05-16T04:06:28+09:00'
+updated_at: '2026-05-16T04:06:28+09:00'
+status: active
+source_type: observation
+scope: harnessops-core
+maturity: hypothesis
+relation: new
+promotion_level: target-lab-case
+source_feedback: FB0009
+eval_cases:
+- E0009
+hypotheses:
+- H0009
+decisions: []
+research_scans: []
+classification:
+  capability: lab_classification_metadata
+  failure_class: missing_classification_backfill_command
+guard:
+  status: not-defined
+  path:
+investigation: []
+links:
+  issue_url:
+---
+
+# IMP0009: FB0009: Adopted lab records need classification backfill
+
+## Status
+
+- status: active
+- maturity: hypothesis
+- source_type: observation
+- scope: harnessops-core
+- relation: new
+- promotion_level: target-lab-case
+- source_feedback: `FB0009`
+- linked_records: `FB0009`, `E0009`, `H0009`
+
+## Source Observation
+
+Source: `harness-lab/records/feedback/FB0009-adopted-lab-records-need-classification-backfill.md`
+
+# FB0009: Adopted lab records need classification backfill
+
+## 概要
+
+During steward queue selection, adopted runops target dossiers IMP0007 and IMP0008 still show capability/failure_class as unclassified even though their decisions and guards identify paper request MCP behavior. The public HOPS classify command exposes maturity, scope, relation, promotion, and guard fields, but not capability/failure_class, so agents cannot backfill classification metadata without direct overlay edits.
+
+## 再現
+
+Inspect harness-lab/views/improvements.md after issues #75 and #77 were adopted; then run uvx --from harnessops hops lab classify --help and note there is no capability or failure-class option.
+
+## 期待する上流変更
+
+HarnessOps should provide a CLI-supported path to backfill capability and failure_class on imported feedback, eval cases, hypotheses, and dossiers, or prevent adoption from leaving those fields unclassified.
+
+## Target Capability
+
+- capability: lab_classification_metadata
+- failure_class: missing_classification_backfill_command
+
+## Investigation
+
+調査メモはまだありません。
+
+## Research Scans
+
+research scan はまだありません。
+
+
+## Evaluation
+
+### E0009: E0009: FB0009-adopted-lab-records-need-classification-backfill を評価
+
+
+- source: `harness-lab/records/eval-cases/E0009-fb0009-adopted-lab-records-need-classification-backfill.md`
+
+- capability: lab_classification_metadata
+
+- failure_class: missing_classification_backfill_command
+
+- manual_eval: 未実施
+
+
+## Hypotheses
+
+### H0009: H0009: E0009-fb0009-adopted-lab-records-need-classification-backfill の仮説
+
+
+Source: `harness-lab/records/hypotheses/H0009-e0009-fb0009-adopted-lab-records-need-classification-backfill.md`
+
+
+# H0009: E0009-fb0009-adopted-lab-records-need-classification-backfill の仮説
+
+## 仮説
+
+Providing a CLI-supported capability/failure_class backfill path, or blocking adoption while those fields remain unclassified, will keep HarnessOps lab queues searchable and evaluable after issue-imported target work is implemented.
+
+## メカニズム
+
+Extend the lab classification workflow so agents can update classification metadata through HOPS commands instead of direct overlay edits, and ensure regenerated feedback, eval, hypothesis, dossier, and view records stay consistent.
+
+## 最小実装
+
+Add a narrow HOPS command option or dedicated subcommand for classification metadata backfill, with validation for non-empty capability and failure_class and regeneration of dependent views/dossiers.
+
+## 代替案: 削除または統合
+
+Keep current classify behavior and rely on initial import classification only, but this leaves adopted imported issues such as IMP0007 and IMP0008 permanently unclassified when the original issue bundle lacked taxonomy.
+
+## 期待される利点
+
+Adopted target work remains discoverable by capability/failure class, and agents can repair metadata without bypassing the managed overlay workflow.
+
+## 想定される欠点
+
+A broad rewrite path could accidentally mutate historical records; the implementation should be narrow, explicit, and covered by a fixture with already-adopted records.
+
+## 評価計画
+
+Create a fixture with an imported feedback/eval/hypothesis/dossier set whose classification is unclassified, run the new backfill path, and assert dependent records/views use the new capability and failure_class without changing decision evidence or guard paths.
+
+## 中止基準
+
+Reject if the path requires direct file edits, rewrites unrelated decision evidence, or allows empty/free-form taxonomy updates that make lab records less consistent.
+
+
+## Evidence
+
+評価結果はまだありません。
+
+## Guard
+
+- status: not-defined
+- path: None
+
+## Links
+
+- issue_url: 未設定
+
+## Open Questions And Next Action
+
+次の実装または評価ステップは、この dossier と紐づく正規化レコードを更新してから再生成してください。
+
+## Decision Log
+
+判断レコードはまだありません。

--- a/harness-lab/records/eval-cases/E0009-fb0009-adopted-lab-records-need-classification-backfill.md
+++ b/harness-lab/records/eval-cases/E0009-fb0009-adopted-lab-records-need-classification-backfill.md
@@ -1,0 +1,41 @@
+---
+id: E0009
+record_type: eval_case
+created_at: '2026-05-16T04:05:50+09:00'
+status: active
+capability: lab_classification_metadata
+failure_class: missing_classification_backfill_command
+source_feedback: FB0009
+---
+
+# E0009: FB0009-adopted-lab-records-need-classification-backfill を評価
+
+## フィクスチャ
+
+- source_feedback: `harness-lab/records/feedback/FB0009-adopted-lab-records-need-classification-backfill.md`
+- fixture_dir: `harness-lab/records/eval-cases/fixtures/E0009`
+- observation: During steward queue selection, adopted runops target dossiers IMP0007 and IMP0008 still show capability/failure_class as unclassified even though their decisions and guards identify paper request MCP behavior. The public HOPS classify command exposes maturity, scope, relation, promotion, and guard fields, but not capability/failure_class, so agents cannot backfill classification metadata without direct overlay edits.
+
+## タスク
+
+`lab_classification_metadata` の `missing_classification_backfill_command` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
+
+Inspect harness-lab/views/improvements.md after issues #75 and #77 were adopted; then run uvx --from harnessops hops lab classify --help and note there is no capability or failure-class option.
+
+## 期待される挙動
+
+HarnessOps should provide a CLI-supported path to backfill capability and failure_class on imported feedback, eval cases, hypotheses, and dossiers, or prevent adoption from leaving those fields unclassified.
+
+## 合格基準
+
+- `missing_classification_backfill_command` の再現条件が検出または防止される。
+- 提案または実装される変更が source feedback の期待変更に対応している。
+- `hops eval --case E0009 --manual` の score と notes で採用判断に必要な証拠を説明できる。
+- 非公開プロジェクト詳細を追加で要求しない。
+
+## 不合格基準
+
+- `missing_classification_backfill_command` の再現条件を見逃す。
+- source feedback の期待変更と無関係な改善案になる。
+- 評価が yml score へ記録されず、採用判断の証拠として追えない。
+- 再現または判断に非公開文脈が必要になる。

--- a/harness-lab/records/feedback/FB0009-adopted-lab-records-need-classification-backfill.md
+++ b/harness-lab/records/feedback/FB0009-adopted-lab-records-need-classification-backfill.md
@@ -1,0 +1,30 @@
+---
+id: FB0009
+record_type: imported_feedback
+created_at: '2026-05-16T04:05:26+09:00'
+status: triaged
+source:
+  type: local-capture
+  original_id: 'harness-lab/views/improvements.md; harness-lab/improvements/IMP0007-fb0007-paper-request-draft-validate-mcp-paperops-handoff.md; harness-lab/improvements/IMP0008-fb0008-paper-request-draft-duplicate-id-append.md; command: uvx --from harnessops hops lab classify --help'
+  source_project: runops
+classification:
+  capability: lab_classification_metadata
+  failure_class: missing_classification_backfill_command
+links:
+  eval_case:
+  issue_url:
+---
+
+# FB0009: Adopted lab records need classification backfill
+
+## 概要
+
+During steward queue selection, adopted runops target dossiers IMP0007 and IMP0008 still show capability/failure_class as unclassified even though their decisions and guards identify paper request MCP behavior. The public HOPS classify command exposes maturity, scope, relation, promotion, and guard fields, but not capability/failure_class, so agents cannot backfill classification metadata without direct overlay edits.
+
+## 再現
+
+Inspect harness-lab/views/improvements.md after issues #75 and #77 were adopted; then run uvx --from harnessops hops lab classify --help and note there is no capability or failure-class option.
+
+## 期待する上流変更
+
+HarnessOps should provide a CLI-supported path to backfill capability and failure_class on imported feedback, eval cases, hypotheses, and dossiers, or prevent adoption from leaving those fields unclassified.

--- a/harness-lab/records/hypotheses/H0009-e0009-fb0009-adopted-lab-records-need-classification-backfill.md
+++ b/harness-lab/records/hypotheses/H0009-e0009-fb0009-adopted-lab-records-need-classification-backfill.md
@@ -1,0 +1,42 @@
+---
+id: H0009
+record_type: hypothesis
+created_at: '2026-05-16T04:06:03+09:00'
+status: proposed
+target_capability: lab_classification_metadata
+source_eval_case: E0009
+---
+
+# H0009: E0009-fb0009-adopted-lab-records-need-classification-backfill の仮説
+
+## 仮説
+
+Providing a CLI-supported capability/failure_class backfill path, or blocking adoption while those fields remain unclassified, will keep HarnessOps lab queues searchable and evaluable after issue-imported target work is implemented.
+
+## メカニズム
+
+Extend the lab classification workflow so agents can update classification metadata through HOPS commands instead of direct overlay edits, and ensure regenerated feedback, eval, hypothesis, dossier, and view records stay consistent.
+
+## 最小実装
+
+Add a narrow HOPS command option or dedicated subcommand for classification metadata backfill, with validation for non-empty capability and failure_class and regeneration of dependent views/dossiers.
+
+## 代替案: 削除または統合
+
+Keep current classify behavior and rely on initial import classification only, but this leaves adopted imported issues such as IMP0007 and IMP0008 permanently unclassified when the original issue bundle lacked taxonomy.
+
+## 期待される利点
+
+Adopted target work remains discoverable by capability/failure class, and agents can repair metadata without bypassing the managed overlay workflow.
+
+## 想定される欠点
+
+A broad rewrite path could accidentally mutate historical records; the implementation should be narrow, explicit, and covered by a fixture with already-adopted records.
+
+## 評価計画
+
+Create a fixture with an imported feedback/eval/hypothesis/dossier set whose classification is unclassified, run the new backfill path, and assert dependent records/views use the new capability and failure_class without changing decision evidence or guard paths.
+
+## 中止基準
+
+Reject if the path requires direct file edits, rewrites unrelated decision evidence, or allows empty/free-form taxonomy updates that make lab records less consistent.

--- a/harness-lab/views/imported-feedback.md
+++ b/harness-lab/views/imported-feedback.md
@@ -9,3 +9,4 @@
 - `FB0006` triaged paper_request_contract missing_paper_to_runops_request_contract
 - `FB0007` triaged unclassified unclassified
 - `FB0008` triaged unclassified unclassified
+- `FB0009` triaged lab_classification_metadata missing_classification_backfill_command

--- a/harness-lab/views/improvements.md
+++ b/harness-lab/views/improvements.md
@@ -9,3 +9,4 @@
 - `IMP0006` adopted maturity=adopted scope=runops-target promotion=target-feature source=FB0006 paper_request_contract missing_paper_to_runops_request_contract
 - `IMP0007` adopted maturity=adopted scope=runops-target promotion=target-feature source=FB0007 unclassified unclassified
 - `IMP0008` adopted maturity=adopted scope=runops-target promotion=target-feature source=FB0008 unclassified unclassified
+- `IMP0009` active maturity=hypothesis scope=harnessops-core promotion=target-lab-case source=FB0009 lab_classification_metadata missing_classification_backfill_command


### PR DESCRIPTION
## Summary
- captured FB0009 for adopted lab records that remain unclassified
- added E0009/H0009 and IMP0009 for the classification backfill workflow gap
- refreshed HarnessOps lab views and lock metadata

## Validation
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run mypy src/
- uv run pytest -q
- uv run runo mcp check
- uvx --from harnessops hops doctor --check-overlay --check-records
- uvx --from harnessops hops migrate --check