### PR TITLE
Daily steward automation

### DIFF
--- a/.harnessops/lock.json
+++ b/.harnessops/lock.json
@@ -41,14 +41,14 @@
       ".claude/skills/hops-update-harness/SKILL.md": "sha256:20b28985e5b3463eac61f00e90dc3cd47060d4d8639aa0d309467b0426ec3748"
     }
   },
-  "harnessops_version": "0.1.14",
+  "harnessops_version": "0.1.15",
   "layout_version": "0.1",
   "managed_files": {
     "harness-lab/README.md": "sha256:795d3e87ce80e3391ec930f263648bd5e667007c771706c50e2dada0311d4526",
     "harness-lab/views/backlog.md": "sha256:0ed4436872ad24f9c73737b7f84290306dc4baaf36154b7e36be521e985b791c",
-    "harness-lab/views/imported-feedback.md": "sha256:2e3b90aeec715bd50e7c76097212b5609fa28d0a2d3d2e0e8125889ff0594508",
-    "harness-lab/views/improvements.md": "sha256:dc16d5ac3033c714897611c7ceebedd2b84dbc2b292f69b4c4893d524446e1f2",
-    "harness-lab/views/research-scans.md": "sha256:7fb10dcd23935a4f8a4dcec803b4efcb22fe433bbb1bf6a994d4af68926068f0",
+    "harness-lab/views/imported-feedback.md": "sha256:bf001b1950d29021d4369d9e0f6cc71c6155215cad27638b7b3fe4f3cf851b7a",
+    "harness-lab/views/improvements.md": "sha256:9c4cfd9c6b6c8eade6379317ad49187a09a08590a0c5b2658b208ca07d644adb",
+    "harness-lab/views/research-scans.md": "sha256:b32262b62d655d37226f3e2757429577af438351f6e9123f10298a0eabd12a26",
     "harness-lab/views/score-trajectory.md": "sha256:a3d2f445609e5e9da0269ece3b10aff2414f3830bd185ad257d32ae19026b616"
   },
   "migrations": [],

--- a/harness-lab/improvements/IMP0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md
+++ b/harness-lab/improvements/IMP0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md
@@ -1,0 +1,189 @@
+---
+id: IMP0016
+record_type: improvement_dossier
+created_at: '2026-05-21T04:17:15+09:00'
+updated_at: '2026-05-21T04:18:58+09:00'
+status: needs-more-evidence
+source_type: local-reproduction
+scope: harnessops-core
+maturity: investigated
+relation: extends
+promotion_level: core-workflow
+source_feedback: FB0016
+eval_cases:
+- E0016
+hypotheses:
+- H0016
+decisions:
+- D0016
+research_scans: []
+classification:
+  capability: target_intent_context
+  failure_class: steward_target_context_inference
+guard:
+  status: candidate
+  path: harnessops-core:tests/test_steward/test_target_intent_context.py::test_pre_lane_context_digest_cites_target_owned_gates
+investigation:
+- created_at: '2026-05-21T04:17:55+09:00'
+  kind: workflow-design
+  summary: 'Priority review connected RS0005 to a concrete upstream workflow gap: runops documents target-owned context surfaces and gates, but autonomous steward lanes only receive lane-local summaries unless a supervisor passes those target facts explicitly. In a runops source checkout, runo context --json correctly fails without runops.toml, so a HOPS pre-lane digest must treat project context as an optional target-owned input and cite fallback docs/rules rather than persisting inferred target memory.'
+  evidence_ref: RS0005; uv run runo context --json ProjectNotFoundError in source checkout; README.md:94-121; docs/agent-user-guide.md:20,70,144-166,197; docs/layers/interface.md:51-55,109-110,127,154-159; docs/mcp.md:35-46,142-143; .codex/rules/commands.md:13
+links:
+  issue_url:
+---
+
+# IMP0016: FB0016: Pre-lane target intent context for steward lanes
+
+## Status
+
+- status: needs-more-evidence
+- maturity: investigated
+- source_type: local-reproduction
+- scope: harnessops-core
+- relation: extends
+- promotion_level: core-workflow
+- source_feedback: `FB0016`
+- linked_records: `FB0016`, `E0016`, `H0016`, `D0016`
+
+## Source Observation
+
+Source: `harness-lab/records/feedback/FB0016-pre-lane-target-intent-context-for-steward-lanes.md`
+
+# FB0016: Pre-lane target intent context for steward lanes
+
+## 概要
+
+Autonomous steward lanes currently infer target intent, memory boundaries, and human gates from scattered target docs and lane-local handoff text. RS0005 captured the need to evaluate a read-only pre-lane context contract sourced from target-owned context surfaces such as runo context --json and documented command gates.
+
+## 再現
+
+Daily steward run 20260521-040240-b6fdb3d produced RS0005 after open-meta and invention observed that priority lanes need target intent and human-gate evidence before implementation; runops already exposes target context via runo context --json and docs.
+
+## 期待する上流変更
+
+HarnessOps should evaluate a narrow pre-lane target intent digest contract that cites target-owned sources for project role, memory boundaries, command authority, and human gates before autonomous lanes make release, submit, cancel, delete, or persistent-memory decisions.
+
+## Target Capability
+
+- capability: target_intent_context
+- failure_class: steward_target_context_inference
+
+## Investigation
+
+- 2026-05-21T04:17:55+09:00 [workflow-design] Priority review connected RS0005 to a concrete upstream workflow gap: runops documents target-owned context surfaces and gates, but autonomous steward lanes only receive lane-local summaries unless a supervisor passes those target facts explicitly. In a runops source checkout, runo context --json correctly fails without runops.toml, so a HOPS pre-lane digest must treat project context as an optional target-owned input and cite fallback docs/rules rather than persisting inferred target memory. (evidence: RS0005; uv run runo context --json ProjectNotFoundError in source checkout; README.md:94-121; docs/agent-user-guide.md:20,70,144-166,197; docs/layers/interface.md:51-55,109-110,127,154-159; docs/mcp.md:35-46,142-143; .codex/rules/commands.md:13)
+
+## Research Scans
+
+research scan はまだありません。
+
+
+## Evaluation
+
+### E0016: E0016: FB0016-pre-lane-target-intent-context-for-steward-lanes を評価
+
+
+- source: `harness-lab/records/eval-cases/E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md`
+
+- capability: target_intent_context
+
+- failure_class: steward_target_context_inference
+
+- manual_eval_yml: `harness-lab/views/eval-results/E0016-manual-score.yml`
+- manual_eval_md: `harness-lab/views/eval-results/E0016-manual-score.md`
+- scores: impact=4, mechanism_clarity=4, evaluability=4, minimality=4, regression_risk=3, operator_burden=3, anti_theater=4, maintainability=4, privacy_sanitization_risk=4
+- notes: RS0005 and priority review show a recurring autonomous-lane gap: target intent, command gates, and memory boundaries are available in target-owned docs and project context surfaces, but not as a narrow pre-lane contract. The candidate is evaluable with fixtures where runo context --json succeeds, fails without runops.toml, and docs/rules provide fallback gate evidence. Implementation should remain read-only and non-authoritative to avoid creating a second target memory inside HOPS.
+
+
+## Hypotheses
+
+### H0016: H0016: E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes の仮説
+
+
+Source: `harness-lab/records/hypotheses/H0016-e0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md`
+
+
+# H0016: E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes の仮説
+
+## 仮説
+
+Providing autonomous steward lanes with a read-only pre-lane target intent digest will reduce unsafe or speculative target-context inference without turning HOPS records into project memory.
+
+## メカニズム
+
+Before lane execution, collect a narrow digest from target-owned sources: project role and overlay mode from .harnessops/project.toml, available project context from runo context --json when a runops.toml project exists, configured agent docs/rules, and explicit high-cost or destructive command gates. Attach source references and mark missing context as unknown instead of inferred.
+
+## 最小実装
+
+In HarnessOps core, add a pre-lane context contract for daily steward runs that records cited target-owned facts in the run ledger or lane input, handles unavailable target context explicitly, and exposes the digest through review context without writing persistent project decisions into HOPS lab records.
+
+## 代替案: 削除または統合
+
+Keep relying on lane prompts and AGENTS/skill text only. This avoids a new contract, but leaves each lane to rediscover target intent and makes human-gate evidence inconsistent across autonomous runs.
+
+## 期待される利点
+
+Lanes can cite the same target-owned authority before release, submit, cancel, delete, memory, or issue actions; supervisors get a reviewable artifact; target repositories avoid duplicated durable memory.
+
+## 想定される欠点
+
+A poorly scoped digest could become metadata theater or a stale second source of truth if it copies decisions instead of citing target-owned sources and unknowns.
+
+## 評価計画
+
+Use steward-run fixtures for a runops project with runo context --json, a source checkout without runops.toml, and docs-defined gates. Assert the digest cites sources, represents unknowns, blocks or flags gated actions without evidence, and is available to invention/priority lanes.
+
+## 中止基準
+
+Reject if the design persists target decisions as HOPS truth, requires direct overlay edits, exposes private project details beyond cited source snippets, or cannot distinguish missing project context from permission to proceed.
+
+
+## Evidence
+
+`harness-lab/views/eval-results/E0016-manual-score.md`
+
+## Guard
+
+- status: candidate
+- path: harnessops-core:tests/test_steward/test_target_intent_context.py::test_pre_lane_context_digest_cites_target_owned_gates
+
+## Links
+
+- issue_url: 未設定
+
+## Open Questions And Next Action
+
+次の実装または評価ステップは、この dossier と紐づく正規化レコードを更新してから再生成してください。
+
+## Decision Log
+
+### D0016: D0016: needs-more-evidence H0016
+
+
+Source: `harness-lab/records/decisions/D0016-needs-more-evidence-h0016.md`
+
+
+# D0016: needs-more-evidence H0016
+
+## 判断
+
+needs-more-evidence
+
+## 理由
+
+The workflow problem is clear and cross-lane, and RS0005 plus E0016 define an evaluable mechanism, but this target repo run has not implemented or validated the HarnessOps core pre-lane context contract.
+
+## 証拠
+
+RS0005; FB0016; E0016 manual score; H0016; priority review observed runo context --json fails without runops.toml in source checkout and docs/rules contain target-owned human-gate evidence.
+
+## 回帰リスク
+
+Medium. A digest could become a stale second source of truth or leak target-private context unless it stays read-only, source-cited, and explicit about unknowns.
+
+## フォローアップ
+
+Implement the HarnessOps core pre-lane target intent context contract with fixtures for project context success, source-checkout missing context, and docs-defined human gates; then rerun review context and decide adoption.
+
+## 回帰ガード
+
+harnessops-core:tests/test_steward/test_target_intent_context.py::test_pre_lane_context_digest_cites_target_owned_gates

--- a/harness-lab/records/decisions/D0016-needs-more-evidence-h0016.md
+++ b/harness-lab/records/decisions/D0016-needs-more-evidence-h0016.md
@@ -1,0 +1,36 @@
+---
+id: D0016
+record_type: decision
+created_at: '2026-05-21T04:18:50+09:00'
+status: needs-more-evidence
+source: H0016
+evidence:
+  summary: RS0005; FB0016; E0016 manual score; H0016; priority review observed runo context --json fails without runops.toml in source checkout and docs/rules contain target-owned human-gate evidence.
+  guard_path: harnessops-core:tests/test_steward/test_target_intent_context.py::test_pre_lane_context_digest_cites_target_owned_gates
+---
+
+# D0016: needs-more-evidence H0016
+
+## 判断
+
+needs-more-evidence
+
+## 理由
+
+The workflow problem is clear and cross-lane, and RS0005 plus E0016 define an evaluable mechanism, but this target repo run has not implemented or validated the HarnessOps core pre-lane context contract.
+
+## 証拠
+
+RS0005; FB0016; E0016 manual score; H0016; priority review observed runo context --json fails without runops.toml in source checkout and docs/rules contain target-owned human-gate evidence.
+
+## 回帰リスク
+
+Medium. A digest could become a stale second source of truth or leak target-private context unless it stays read-only, source-cited, and explicit about unknowns.
+
+## フォローアップ
+
+Implement the HarnessOps core pre-lane target intent context contract with fixtures for project context success, source-checkout missing context, and docs-defined human gates; then rerun review context and decide adoption.
+
+## 回帰ガード
+
+harnessops-core:tests/test_steward/test_target_intent_context.py::test_pre_lane_context_digest_cites_target_owned_gates

--- a/harness-lab/records/eval-cases/E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md
+++ b/harness-lab/records/eval-cases/E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md
@@ -1,0 +1,41 @@
+---
+id: E0016
+record_type: eval_case
+created_at: '2026-05-21T04:18:04+09:00'
+status: active
+capability: target_intent_context
+failure_class: steward_target_context_inference
+source_feedback: FB0016
+---
+
+# E0016: FB0016-pre-lane-target-intent-context-for-steward-lanes を評価
+
+## フィクスチャ
+
+- source_feedback: `harness-lab/records/feedback/FB0016-pre-lane-target-intent-context-for-steward-lanes.md`
+- fixture_dir: `harness-lab/records/eval-cases/fixtures/E0016`
+- observation: Autonomous steward lanes currently infer target intent, memory boundaries, and human gates from scattered target docs and lane-local handoff text. RS0005 captured the need to evaluate a read-only pre-lane context contract sourced from target-owned context surfaces such as runo context --json and documented command gates.
+
+## タスク
+
+`target_intent_context` の `steward_target_context_inference` を減らす最小変更を設計または実装し、次の再現条件が解消されるか評価してください。
+
+Daily steward run 20260521-040240-b6fdb3d produced RS0005 after open-meta and invention observed that priority lanes need target intent and human-gate evidence before implementation; runops already exposes target context via runo context --json and docs.
+
+## 期待される挙動
+
+HarnessOps should evaluate a narrow pre-lane target intent digest contract that cites target-owned sources for project role, memory boundaries, command authority, and human gates before autonomous lanes make release, submit, cancel, delete, or persistent-memory decisions.
+
+## 合格基準
+
+- `steward_target_context_inference` の再現条件が検出または防止される。
+- 提案または実装される変更が source feedback の期待変更に対応している。
+- `hops lab eval --case E0016 --manual` の score と notes で採用判断に必要な証拠を説明できる。
+- 非公開プロジェクト詳細を追加で要求しない。
+
+## 不合格基準
+
+- `steward_target_context_inference` の再現条件を見逃す。
+- source feedback の期待変更と無関係な改善案になる。
+- 評価が yml score へ記録されず、採用判断の証拠として追えない。
+- 再現または判断に非公開文脈が必要になる。

--- a/harness-lab/records/feedback/FB0016-pre-lane-target-intent-context-for-steward-lanes.md
+++ b/harness-lab/records/feedback/FB0016-pre-lane-target-intent-context-for-steward-lanes.md
@@ -1,0 +1,30 @@
+---
+id: FB0016
+record_type: imported_feedback
+created_at: '2026-05-21T04:17:04+09:00'
+status: triaged
+source:
+  type: local-capture
+  original_id: RS0005; README.md; docs/agent-user-guide.md; docs/layers/interface.md; docs/layers/execution-kernel.md; docs/mcp.md; .codex/rules/commands.md
+  source_project: runops
+classification:
+  capability: target_intent_context
+  failure_class: steward_target_context_inference
+links:
+  eval_case:
+  issue_url:
+---
+
+# FB0016: Pre-lane target intent context for steward lanes
+
+## 概要
+
+Autonomous steward lanes currently infer target intent, memory boundaries, and human gates from scattered target docs and lane-local handoff text. RS0005 captured the need to evaluate a read-only pre-lane context contract sourced from target-owned context surfaces such as runo context --json and documented command gates.
+
+## 再現
+
+Daily steward run 20260521-040240-b6fdb3d produced RS0005 after open-meta and invention observed that priority lanes need target intent and human-gate evidence before implementation; runops already exposes target context via runo context --json and docs.
+
+## 期待する上流変更
+
+HarnessOps should evaluate a narrow pre-lane target intent digest contract that cites target-owned sources for project role, memory boundaries, command authority, and human gates before autonomous lanes make release, submit, cancel, delete, or persistent-memory decisions.

--- a/harness-lab/records/hypotheses/H0016-e0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md
+++ b/harness-lab/records/hypotheses/H0016-e0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md
@@ -1,0 +1,42 @@
+---
+id: H0016
+record_type: hypothesis
+created_at: '2026-05-21T04:18:31+09:00'
+status: proposed
+target_capability: target_intent_context
+source_eval_case: E0016
+---
+
+# H0016: E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes の仮説
+
+## 仮説
+
+Providing autonomous steward lanes with a read-only pre-lane target intent digest will reduce unsafe or speculative target-context inference without turning HOPS records into project memory.
+
+## メカニズム
+
+Before lane execution, collect a narrow digest from target-owned sources: project role and overlay mode from .harnessops/project.toml, available project context from runo context --json when a runops.toml project exists, configured agent docs/rules, and explicit high-cost or destructive command gates. Attach source references and mark missing context as unknown instead of inferred.
+
+## 最小実装
+
+In HarnessOps core, add a pre-lane context contract for daily steward runs that records cited target-owned facts in the run ledger or lane input, handles unavailable target context explicitly, and exposes the digest through review context without writing persistent project decisions into HOPS lab records.
+
+## 代替案: 削除または統合
+
+Keep relying on lane prompts and AGENTS/skill text only. This avoids a new contract, but leaves each lane to rediscover target intent and makes human-gate evidence inconsistent across autonomous runs.
+
+## 期待される利点
+
+Lanes can cite the same target-owned authority before release, submit, cancel, delete, memory, or issue actions; supervisors get a reviewable artifact; target repositories avoid duplicated durable memory.
+
+## 想定される欠点
+
+A poorly scoped digest could become metadata theater or a stale second source of truth if it copies decisions instead of citing target-owned sources and unknowns.
+
+## 評価計画
+
+Use steward-run fixtures for a runops project with runo context --json, a source checkout without runops.toml, and docs-defined gates. Assert the digest cites sources, represents unknowns, blocks or flags gated actions without evidence, and is available to invention/priority lanes.
+
+## 中止基準
+
+Reject if the design persists target decisions as HOPS truth, requires direct overlay edits, exposes private project details beyond cited source snippets, or cannot distinguish missing project context from permission to proceed.

--- a/harness-lab/records/research-scans/RS0005-target-intent-and-human-gate-context-before-steward-lanes.md
+++ b/harness-lab/records/research-scans/RS0005-target-intent-and-human-gate-context-before-steward-lanes.md
@@ -1,0 +1,75 @@
+---
+id: RS0005
+record_type: research_scan
+created_at: '2026-05-21T04:13:30+09:00'
+status: captured
+scope: harnessops-core
+existing_dossier:
+classification:
+  capability: target_intent_context
+  failure_class: steward_target_context_inference
+evidence:
+  local:
+  - summary: Open-meta scan found steward lanes infer runops target intent, memory boundaries, and human gates from scattered docs while automation memory tracks lane-local state.
+    ref: automation memory 20260521-040240-b6fdb3d; open-meta raw ideas 1-3
+  codebase:
+  - summary: runops documents agent context via runo context --json, project memory, explicit human gates, and high-cost lifecycle commands; paper/MCP docs keep experiment requests plan-only and disable submit/cancel/delete by default.
+    ref: README.md:94; README.md:120; docs/agent-user-guide.md:20; docs/agent-user-guide.md:70; docs/layers/interface.md:55; docs/layers/execution-kernel.md:105; docs/mcp.md:44; docs/mcp.md:143; .codex/rules/commands.md:13
+  external: []
+  risk:
+  - summary: A durable digest can drift from target source-of-truth if copied into HOPS records; keep it as a generated/pre-lane read model or context contract, not a second project memory.
+    ref: docs/layers/knowledge.md:556; docs/agent-user-guide.md:197
+candidates:
+- title: Pre-lane target-intent digest
+  relation: new
+  recommendation: Evaluate a generated digest sourced from runo context --json plus configured docs before autonomous steward lanes; do not persist target decisions as HOPS truth.
+  next_command: hops lab eval-case create after priority selection
+- title: Human-gate evidence requirement
+  relation: extends target-intent digest
+  recommendation: Require autonomous lanes to cite target-owned gate evidence before submit/cancel/delete/release-like actions; keep gates advisory unless target docs mark them blocking.
+  next_command: hops lab investigate/classify after priority selection
+recommendation: Queue as a workflow-design research candidate; priority lane should evaluate a read-only context contract before any implementation.
+---
+
+# RS0005: Target intent and human-gate context before steward lanes
+
+## Scope
+
+- scope: harnessops-core
+- existing_dossier: 未設定
+- capability: target_intent_context
+- failure_class: steward_target_context_inference
+
+## Evidence
+
+### Local
+
+- Open-meta scan found steward lanes infer runops target intent, memory boundaries, and human gates from scattered docs while automation memory tracks lane-local state. (ref: automation memory 20260521-040240-b6fdb3d; open-meta raw ideas 1-3)
+
+### Codebase
+
+- runops documents agent context via runo context --json, project memory, explicit human gates, and high-cost lifecycle commands; paper/MCP docs keep experiment requests plan-only and disable submit/cancel/delete by default. (ref: README.md:94; README.md:120; docs/agent-user-guide.md:20; docs/agent-user-guide.md:70; docs/layers/interface.md:55; docs/layers/execution-kernel.md:105; docs/mcp.md:44; docs/mcp.md:143; .codex/rules/commands.md:13)
+
+### External
+
+- なし
+
+### Risk And Counterexample
+
+- A durable digest can drift from target source-of-truth if copied into HOPS records; keep it as a generated/pre-lane read model or context contract, not a second project memory. (ref: docs/layers/knowledge.md:556; docs/agent-user-guide.md:197)
+
+## Candidates
+
+| candidate | relation | recommendation | next_command |
+|---|---|---|---|
+| Pre-lane target-intent digest | new | Evaluate a generated digest sourced from runo context --json plus configured docs before autonomous steward lanes; do not persist target decisions as HOPS truth. | hops lab eval-case create after priority selection |
+| Human-gate evidence requirement | extends target-intent digest | Require autonomous lanes to cite target-owned gate evidence before submit/cancel/delete/release-like actions; keep gates advisory unless target docs mark them blocking. | hops lab investigate/classify after priority selection |
+
+## Recommendation
+
+Queue as a workflow-design research candidate; priority lane should evaluate a read-only context contract before any implementation.
+
+## Next Commands
+
+- `hops lab eval-case create after priority selection`
+- `hops lab investigate/classify after priority selection`

--- a/harness-lab/views/eval-results/E0016-manual-score.md
+++ b/harness-lab/views/eval-results/E0016-manual-score.md
@@ -1,0 +1,26 @@
+<!-- harnessops により生成; source records が正本 -->
+# 手動評価結果: E0016
+
+送信元: `harness-lab/records/eval-cases/E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md`
+
+## スコア
+
+- impact: 4
+- mechanism_clarity: 4
+- evaluability: 4
+- minimality: 4
+- regression_risk: 3
+- operator_burden: 3
+- anti_theater: 4
+- maintainability: 4
+- privacy_sanitization_risk: 4
+
+## メモ
+
+RS0005 and priority review show a recurring autonomous-lane gap: target intent, command gates, and memory boundaries are available in target-owned docs and project context surfaces, but not as a narrow pre-lane contract. The candidate is evaluable with fixtures where runo context --json succeeds, fails without runops.toml, and docs/rules provide fallback gate evidence. Implementation should remain read-only and non-authoritative to avoid creating a second target memory inside HOPS.
+
+## 評価ケース
+
+- capability: target_intent_context
+- failure_class: steward_target_context_inference
+- source_feedback: FB0016

--- a/harness-lab/views/eval-results/E0016-manual-score.yml
+++ b/harness-lab/views/eval-results/E0016-manual-score.yml
@@ -1,0 +1,17 @@
+schema_version: '0.1'
+record_type: manual_eval_result
+created_at: '2026-05-21T04:18:16+09:00'
+eval_case: E0016
+experiment:
+scores:
+  impact: 4
+  mechanism_clarity: 4
+  evaluability: 4
+  minimality: 4
+  regression_risk: 3
+  operator_burden: 3
+  anti_theater: 4
+  maintainability: 4
+  privacy_sanitization_risk: 4
+notes: 'RS0005 and priority review show a recurring autonomous-lane gap: target intent, command gates, and memory boundaries are available in target-owned docs and project context surfaces, but not as a narrow pre-lane contract. The candidate is evaluable with fixtures where runo context --json succeeds, fails without runops.toml, and docs/rules provide fallback gate evidence. Implementation should remain read-only and non-authoritative to avoid creating a second target memory inside HOPS.'
+source_record: harness-lab/records/eval-cases/E0016-fb0016-pre-lane-target-intent-context-for-steward-lanes.md

--- a/harness-lab/views/imported-feedback.md
+++ b/harness-lab/views/imported-feedback.md
@@ -16,3 +16,4 @@
 - `FB0013` triaged unclassified unclassified
 - `FB0014` triaged unclassified unclassified
 - `FB0015` triaged steward_lane_handoff transient_lane_artifact_loss
+- `FB0016` triaged target_intent_context steward_target_context_inference

--- a/harness-lab/views/improvements.md
+++ b/harness-lab/views/improvements.md
@@ -16,3 +16,4 @@
 - `IMP0013` needs-more-evidence maturity=investigated scope=harnessops-core promotion=core-workflow source=FB0013 unclassified unclassified
 - `IMP0014` needs-more-evidence maturity=investigated scope=harnessops-core promotion=core-workflow source=FB0014 unclassified unclassified
 - `IMP0015` needs-more-evidence maturity=investigated scope=harnessops-core promotion=core-workflow source=FB0015 steward_lane_handoff transient_lane_artifact_loss
+- `IMP0016` needs-more-evidence maturity=investigated scope=harnessops-core promotion=core-workflow source=FB0016 target_intent_context steward_target_context_inference

--- a/harness-lab/views/research-scans.md
+++ b/harness-lab/views/research-scans.md
@@ -5,3 +5,4 @@
 - `RS0002` captured lab_classification_metadata missing_import_taxonomy_gate scope=harnessops-core recommendation=classify existing IMP0009 and queue taxonomy gating before manual scoring
 - `RS0003` captured steward_lane_handoff transient_lane_artifact_loss scope=harnessops-core recommendation=Queue for priority review as a workflow-design research candidate; do not implement until schema, expiry, and promotion rules are evaluated.
 - `RS0004` captured steward_validation repo_role_validation_blindspot scope=harnessops-core recommendation=Queue for later priority review; prefer target-owned health signal contracts over baking runops checks into HOPS core.
+- `RS0005` captured target_intent_context steward_target_context_inference scope=harnessops-core recommendation=Queue as a workflow-design research candidate; priority lane should evaluate a read-only context contract before any implementation.


### PR DESCRIPTION
Summary:
- Updated HarnessOps lock to 0.1.15 and managed lab view hashes.
- Added RS0005 plus FB0016/IMP0016/E0016/H0016/D0016 for pre-lane target intent context.
- Validation passed: ruff format/check, mypy, pytest, coverage, git diff --check, hops doctor, hops migrate.

Release: not performed; no repo-native release criteria/version change in this lane.