### PR TITLE
[codex] expose advisory codex plugin contracts

### DIFF
--- a/.agents/skills/beach/SKILL.md
+++ b/.agents/skills/beach/SKILL.md
@@ -1,197 +1,52 @@
 ---
 name: beach
-description: "Use when working with the BEACH (BEM + Accumulated CHarge) simulator in runops: generating or editing beach.toml, creating runs, checking BEACH outputs, analyzing CSV results, or producing BEACH visualizations."
+description: "Use when working with BEACH through runops. Keep this as a thin runops bridge; delegate BEACH-specific config review, case design, diagnosis, output analysis, and visualization to the BEACH Context plugin when it is available."
 ---
 
-あなたは BEACH (BEM + Accumulated CHarge) シミュレータの専門エージェントです。
-境界要素法による表面帯電シミュレーションの実行管理、データ処理、可視化を担当します。
+# BEACH runops bridge
 
-## BEACH について
+この skill は runops 開発リポジトリ側の薄い橋渡しである。BEACH 固有の
+長文知識、物理・数値判断、出力解析、可視化 workflow は外部 Codex plugin
+`BEACH Context` (`beach-context`) に委譲する。runops 側では run directory、
+case/survey 展開、manifest、adapter contract、job.sh 生成、lint/test/docs の
+整合性だけを扱う。
 
-- **リポジトリ**: https://github.com/Nkzono99/BEACH
-- **種類**: 境界要素法 (BEM) による表面帯電シミュレーション
-- **言語**: Fortran (コア) + Python (ライブラリ・後処理)
-- **インストール**: `pip install beach-bem`
-- **入力**: TOML 形式 (`beach.toml`)
-- **出力**: CSV ファイル (charges.csv, mesh_triangles.csv 等)
-- **実行**: `beach beach.toml` または `mpirun -np N beach beach.toml`
-- **後処理ツール**: `beachx` コマンド群
+## 最初に確認すること
 
-## 入力ファイル (beach.toml)
+1. 対象 project で `runo plugins --check` または `runo plugins --json` を確認し、
+   `beach-context` 推薦と `delegated_capabilities` を見る。
+2. 現在の Codex session で `BEACH Context` plugin / skill が利用可能なら、
+   `config-review`, `case-design`, `run-diagnose`, `output-analysis`,
+   `visualization-script` はそちらを使う。
+3. plugin が利用できない場合だけ、この skill の最小情報と現在の project files
+   (`case.toml`, `beach.toml`, `manifest.toml`, run output) を根拠にする。
 
-TOML 形式の設定ファイル。主要セクション：
+## runops 側で担当すること
 
-```toml
-[sim]
-dt = 1.4e-8
-batch_count = 10
-max_step = 500
-field_solver = "default"
-box_origin = [0.0, 0.0, 0.0]
-box_size = [1.0, 1.0, 1.0]
+- `src/runops/adapters/contrib/beach/adapter.py` の adapter contract、runtime
+  resolution、required outputs、summary parsing を保つ。
+- `runo create`, `runo submit`, `runo status`, `runo summarize`, `runo collect`
+  から見た runops workflow を壊さない。
+- BEACH project では `runo plugins` が `BEACH Context` / `beach-context` と
+  委譲 role を表示することを確認する。
+- KUDPC 上で実行やテストを行う場合は KUDPC plugin の routing に従い、login node
+  で solver、pytest、可視化、重い解析を直接実行しない。
 
-[[particles.species]]
-name = "electron"
-q_particle = -1.602e-19
-m_particle = 9.109e-31
-temperature_ev = 1.0
-source_mode = "reservoir_face"
+## 最小 fallback
 
-[[particles.species]]
-name = "ion"
-q_particle = 1.602e-19
-m_particle = 9.109e-28
-temperature_ev = 0.1
-source_mode = "reservoir_face"
+- 入力は `beach.toml`、runops case は adapter がそれを `work/` に配置する。
+- 代表的な output は `summary.txt`、`charges.csv`、`mesh_triangles.csv`、
+  `charge_history.csv`、`potential_history.csv`。
+- `summary.txt` は runops の完了判定と要約の主な入口である。
+- 詳細な parameter 意味、安定性判断、図化手順は plugin または BEACH upstream
+  docs を根拠にし、この repository の古い記憶で補完しない。
 
-[mesh]
-mode = "template"
-template = "sphere"
-radius = 0.1
-center = [0.5, 0.5, 0.5]
+## 変更時の検証
 
-[output]
-dir = "outputs/latest"
-history_stride = 10
-write_potential_history = true
-```
-
-### CLI ワークフロー
-```bash
-beachx config init          # case.toml をプリセットから生成
-beachx config validate      # 設定の検証
-beachx config render        # case.toml → beach.toml の変換
-beach beach.toml            # シミュレーション実行
-```
-
-## HPC 環境
-
-- Python venv の activate が必要: `source /path/to/venv/bin/activate`
-- venv 自動検出: `resolve_runtime` が cwd から上位ディレクトリを辿って `.venv` を自動検出。`simulators.toml` の `venv_path` が未設定でも動作する
-- module load は不要 (Python パッケージとして完結)
-- MPI 並列対応: `mpirun -np N beach beach.toml` or `srun beach beach.toml`
-
-### 典型的な job.sh
-```bash
-#!/bin/bash
-#SBATCH -p gr10451a
-#SBATCH --rsc p=4:t=1:c=1
-#SBATCH -t 24:00:00
-
-source /path/to/venv/bin/activate
-
-cd work/
-beach beach.toml
-
-# Post-processing
-beachx inspect outputs/latest --save-mesh mesh.png
-beachx coulomb outputs/latest --component z --save coulomb_z.png
-```
-
-## 実行管理タスク
-
-### 入力ファイル生成
-- beach.toml の生成・編集
-- パラメータの検証
-- メッシュ設定の構成
-
-### ジョブ投入
-- job.sh 生成 (venv activation 付き)
-- MPI プロセス数の設定
-
-### 状態監視
-- summary.txt の確認
-- 出力 CSV ファイルの存在チェック
-- エラー検出
-
-## データ処理タスク
-
-### 出力ファイル
-- `summary.txt`: 実行サマリ
-- `charges.csv`: メッシュ要素ごとの電荷分布
-- `mesh_triangles.csv`: メッシュ形状定義（三角形要素）
-- `charge_history.csv`: 電荷の時間発展
-- `potential_history.csv`: 電位の時間発展
-
-### Python API による読み込み
-```python
-from beach import Beach
-
-# 結果の読み込み
-b = Beach("outputs/latest")
-result = b.result
-
-# 電荷データ
-import pandas as pd
-charges = pd.read_csv("outputs/latest/charges.csv")
-mesh = pd.read_csv("outputs/latest/mesh_triangles.csv")
-```
-
-### CSV 直接読み込み
-```python
-import pandas as pd
-import numpy as np
-
-# 電荷分布
-charges = pd.read_csv("work/outputs/latest/charges.csv")
-print(f"Total charge: {charges['charge'].sum():.6e} C")
-print(f"Max charge density: {charges['charge'].max():.6e} C")
-
-# 時間発展
-history = pd.read_csv("work/outputs/latest/charge_history.csv")
-```
-
-## 可視化タスク
-
-### beachx コマンドによる可視化
-```bash
-# メッシュと電荷分布の可視化
-beachx inspect outputs/latest --save-mesh analysis/figures/mesh.png
-
-# アニメーション生成
-beachx animate outputs/latest --quantity potential --save-gif analysis/figures/potential.gif
-
-# クーロン力の可視化
-beachx coulomb outputs/latest --component z --save analysis/figures/coulomb_z.png
-
-# 移動度解析
-beachx mobility outputs/latest --density-kg-m3 2500 --mu-static 0.4
-```
-
-### Python による可視化
-```python
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-
-# 電荷の時間発展
-history = pd.read_csv("work/outputs/latest/charge_history.csv")
-plt.figure(figsize=(10, 6))
-plt.plot(history["step"], history["total_charge"])
-plt.xlabel("Step")
-plt.ylabel("Total Charge (C)")
-plt.title("Charge Accumulation Over Time")
-plt.grid(True)
-plt.savefig("analysis/figures/charge_history.png", dpi=150, bbox_inches="tight")
-
-# 電荷分布のヒートマップ
-charges = pd.read_csv("work/outputs/latest/charges.csv")
-mesh = pd.read_csv("work/outputs/latest/mesh_triangles.csv")
-# 三角形メッシュ上の電荷分布を matplotlib.tri で可視化
-from matplotlib.tri import Triangulation
-# ... (メッシュデータに応じて構成)
-```
-
-### 注意事項
-- BEACH の Python API (`from beach import Beach`) を使うには `beach-bem` パッケージが必要
-- `beachx` コマンドは BEACH インストール時に一緒にインストールされる
-- venv 環境の activate を忘れずに
-- 解析結果は `analysis/` ディレクトリに保存
-- 図は `analysis/figures/` に保存
-
-## コマンド実行時の注意
-
-- BEACH の Python 環境は venv で管理されている
-- プロジェクトルート付近に venv がある想定
-- `source venv/bin/activate` してから Python/beachx コマンドを実行
-- 大量のメッシュデータの処理はメモリに注意
+- Adapter 変更: `tests/test_adapters/test_beach.py`,
+  `tests/test_adapters/test_contract.py`
+- plugin 推薦変更: `tests/test_core/test_plugins.py`,
+  `tests/test_cli/test_plugins.py`, `tests/test_core/test_context.py`,
+  `tests/test_mcp/test_tools.py`
+- harness 表示変更: `tests/test_harness/test_codex.py`,
+  `tests/test_cli/test_init.py`, `tests/test_cli/test_update_harness.py`

--- a/.agents/skills/emses/SKILL.md
+++ b/.agents/skills/emses/SKILL.md
@@ -1,145 +1,55 @@
 ---
 name: emses
-description: "Use when working with the MPIEMSES3D simulator in runops: generating plasma.inp, designing EMSES runs, checking stdout/HDF5 outputs, analyzing EMSES data, or producing EMSES visualizations."
+description: "Use when working with MPIEMSES3D through runops. Keep this as a thin runops bridge; delegate simulator-specific parameter design, input review, run diagnosis, output analysis, and visualization to MPIEMSES3D Context and emout Context plugins when available."
 ---
 
-あなたは MPIEMSES3D (3D 電磁 PIC プラズマシミュレータ) の専門エージェントです。
-シミュレーションの実行管理、入力ファイル生成、データ処理、可視化を担当します。
+# EMSES runops bridge
 
-## MPIEMSES3D について
+この skill は runops 開発リポジトリ側の薄い橋渡しである。MPIEMSES3D 固有の
+長文知識、物理・数値判断、`plasma.inp` review、run diagnosis、HDF5/emout
+解析、可視化 workflow は外部 Codex plugin `MPIEMSES3D Context`
+(`mpiemses3d-context`) と `emout Context` (`emout-context`) に委譲する。
+runops 側では run directory、case/survey 展開、manifest、adapter contract、
+launcher/job.sh、lint/test/docs の整合性だけを扱う。
 
-- **リポジトリ**: https://github.com/CS12-Laboratory/MPIEMSES3D
-- **種類**: 3D 電磁粒子シミュレーション (Particle-in-Cell, PIC)
-- **言語**: Fortran + MPI
-- **入力**: Fortran namelist 形式 (`plasma.inp`, optional `plasma.preinp`)
-- **出力**: HDF5 ファイル (`*_0000.h5` 等)、stdout/stderr ログ
-- **実行**: `srun ./mpiemses3D plasma.inp`
+## 最初に確認すること
 
-## 入力ファイル (plasma.inp)
+1. 対象 project で `runo plugins --check` または `runo plugins --json` を確認し、
+   `mpiemses3d-context` / `emout-context` 推薦と `delegated_capabilities` を見る。
+2. 現在の Codex session で external plugin / skill が利用可能なら、
+   `input-review`, `parameter-design`, `run-diagnose`, `output-analysis`,
+   `visualization-script` はそちらを使う。
+3. plugin が利用できない場合だけ、この skill の最小情報と現在の project files
+   (`case.toml`, `plasma.inp`, `manifest.toml`, stdout/HDF5 output) を根拠にする。
 
-Fortran namelist 形式。主要なパラメータ：
+## runops 側で担当すること
 
-```fortran
-&tmgrid
-  nx = 256, ny = 256, nz = 512
-  dt = 1.0e-8
-/
+- `src/runops/adapters/contrib/emses/adapter.py` の adapter contract、runtime
+  resolution、input rendering、required outputs、summary parsing を保つ。
+- launcher / jobgen では Python を MPI rank wrapper にせず、job.sh から
+  `srun` / `mpirun` / `mpiexec` を直接起動する境界を守る。
+- `runo create`, `runo submit`, `runo status`, `runo summarize`, `runo collect`
+  から見た runops workflow を壊さない。
+- EMSES project では `runo plugins` が `MPIEMSES3D Context` と `emout Context`
+  の委譲 role を表示することを確認する。
+- KUDPC 上で実行やテストを行う場合は KUDPC plugin の routing に従い、login node
+  で solver、pytest、可視化、重い解析を直接実行しない。
 
-&jobcon
-  nstep = 10000
-/
+## 最小 fallback
 
-&mpi
-  nodes(1:3) = 4, 4, 8            ! 領域分割 (MPI プロセス数 = 4*4*8 = 128)
-/
-```
+- 代表入力は `plasma.inp` と optional `plasma.preinp`。
+- 代表 output は stdout/stderr log と `*_0000.h5` 系 HDF5 files。
+- runops の状態追跡は `manifest.toml` と adapter output detection を正本にする。
+- 詳細な namelist 意味、安定性判断、emout API、図化手順は plugin または upstream
+  docs を根拠にし、この repository の古い記憶で補完しない。
 
-主要な namelist グループ: `esorem`, `jobcon`, `digcon`, `plasma`, `tmgrid`, `system`, `mpi`, `intp`, `ptcond`, `gradema`, `dipole`, `emissn`, `inp`, `testch`, `jsrc`, `verbose`
+## 変更時の検証
 
-- `&tmgrid`: グリッド定義 (`nx`, `ny`, `nz`, `dt` 等)
-- `&mpi` / `nodes(1:3)`: 各軸の領域分割数。総 MPI プロセス数 = product(nodes)
-- `&jobcon` / `nstep`: 総ステップ数
-- `&plasma`: プラズマパラメータ (`wc`, `phiz` 等)
-
-## HPC 環境
-
-- カスタム Slurm: `#SBATCH --rsc p=N:t=T:c=C`
-- module: `intel/2023.2`, `intelmpi/2023.2`, `hdf5/1.12.2_intel-2023.2-impi`, `fftw/3.3.10_intel-2022.3-impi`
-- 前処理: `preinp` コマンド (plasma.preinp がある場合)
-- 後処理: `mypython plot.py ./`, `mypython plot_hole.py ./`
-- sbatch ラッパー: `mysbatch job.sh` (plasma.inp から自動的にプロセス数を設定)
-- venv 自動検出: `resolve_runtime` が cwd から上位ディレクトリを辿って `.venv` を自動検出。`simulators.toml` の `venv_path` が未設定でも動作する
-
-## 実行管理タスク
-
-### 入力ファイル生成
-- Fortran namelist のパース・生成
-- パラメータの変更・検証
-- 領域分割の最適化提案（nxs, nys, nzs の組み合わせ）
-
-### ジョブ投入
-- job.sh 生成（rsc モード、module load 付き）
-- プロセス数の自動計算: `&mpi` グループの `nodes(1:3)` から product(nodes) で算出
-- walltime の見積もり
-
-### 状態監視
-- stdout ログの解析（タイムステップ進捗）
-- HDF5 出力の確認
-- エラー検出
-
-## データ処理タスク
-
-### HDF5 データ読み込み (emout 推奨)
-```python
-import emout
-
-# emout による読み込み (単位変換対応)
-data = emout.Emses("work/")
-phi = data.phisp[0]  # 電位 (タイムステップ 0)
-nd1 = data.nd1p[0]   # 粒子密度 (種1)
-```
-
-### HDF5 直接読み込み
-```python
-import h5py
-import numpy as np
-
-with h5py.File("work/phisp00_0000.h5", "r") as f:
-    data = f[list(f.keys())[0]][:]
-```
-
-### 典型的な出力ファイル
-- `phisp00_0000.h5`: 電位
-- `nd1p00_0000.h5`, `nd2p00_0000.h5`: 粒子数密度 (種ごと)
-- `rho00_0000.h5`: 電荷密度
-- `ex00_0000.h5`, `ey00_0000.h5`, `ez00_0000.h5`: 電場
-- `bz00_0000.h5` 等: 磁場
-- `j1x00_0000.h5`, `j1y00_0000.h5`, `j1z00_0000.h5`: 電流密度
-- `p4xe00_0000.h5` 等: 粒子位置・速度 (粒子種ごと)
-- ファイル名の `00` はリージョン番号、`0000` はタイムステップ
-
-### 関連 Python パッケージ
-- `emout`: EMSES 出力 HDF5 の読み込み・単位変換 (`pip install emout`)
-- `camptools`: ワークフロー管理・パラメータスイープ (`pip install camptools`)
-- `preinp`: Fortran namelist 前処理ツール (`pip install preinp`)
-
-## 可視化タスク
-
-### 2D スライス
-```python
-import matplotlib.pyplot as plt
-import h5py
-
-with h5py.File("work/phi_0000.h5", "r") as f:
-    phi = f["phi"][:]
-
-# XY 平面のスライス
-plt.figure(figsize=(10, 8))
-plt.pcolormesh(phi[:, :, phi.shape[2]//2].T, cmap="RdBu_r")
-plt.colorbar(label="Potential")
-plt.xlabel("X")
-plt.ylabel("Y")
-plt.title("Electrostatic Potential (XY plane)")
-plt.savefig("analysis/figures/phi_xy.png", dpi=150, bbox_inches="tight")
-```
-
-### 時間発展
-```python
-import glob
-import re
-
-# タイムステップごとのファイルをソート
-files = sorted(glob.glob("work/phi_*.h5"), key=lambda f: int(re.search(r'(\d+)\.h5', f).group(1)))
-```
-
-### 注意事項
-- HDF5 ファイルは大容量になりうる。メモリに注意
-- `mypython` は環境固有のコマンド。標準 Python で代替する場合は `h5py` + `matplotlib` を使用
-- 解析結果は `analysis/` ディレクトリに保存
-- 図は `analysis/figures/` に保存
-
-## コマンド実行時の注意
-
-- `uv run` でプロジェクトの Python 環境を使用
-- HDF5 の読み書きには `h5py` が必要（別途インストール）
-- 大容量データの処理はメモリを考慮して chunk 単位で処理
+- Adapter 変更: `tests/test_adapters/test_emses.py`,
+  `tests/test_adapters/test_contract.py`
+- launcher/job.sh 変更: `tests/test_launchers/`, `tests/test_slurm/test_jobgen.py`
+- plugin 推薦変更: `tests/test_core/test_plugins.py`,
+  `tests/test_cli/test_plugins.py`, `tests/test_core/test_context.py`,
+  `tests/test_mcp/test_tools.py`
+- harness 表示変更: `tests/test_harness/test_codex.py`,
+  `tests/test_cli/test_init.py`, `tests/test_cli/test_update_harness.py`

--- a/.claude/agents/beach.md
+++ b/.claude/agents/beach.md
@@ -1,198 +1,43 @@
 ---
 name: beach
-description: "BEACH (BEM + Accumulated CHarge) シミュレータの操作エージェント。実行管理、データ処理、可視化を担当する。\n\nExamples:\n\n<example>\nuser: \"BEACH のシミュレーション結果を可視化して\"\nassistant: \"BEACH エージェントを使って可視化を行います。\"\n</example>\n\n<example>\nuser: \"beach.toml のパラメータを変えて新しい run を作りたい\"\nassistant: \"BEACH エージェントで beach.toml を生成して run を作成します。\"\n</example>\n\n<example>\nuser: \"BEACH の電荷分布を解析して\"\nassistant: \"BEACH エージェントで charges.csv の解析を行います。\"\n</example>"
+description: "BEACH を runops から扱うための薄い橋渡しエージェント。BEACH 固有の config review、case design、diagnosis、output analysis、visualization は BEACH Context plugin に委譲し、runops 側の run directory、adapter、manifest、job/harness 整合性を担当する。"
 model: sonnet
 ---
 
-あなたは BEACH (BEM + Accumulated CHarge) シミュレータの専門エージェントです。
-境界要素法による表面帯電シミュレーションの実行管理、データ処理、可視化を担当します。
+# BEACH runops bridge
 
-## BEACH について
+この agent は runops 開発リポジトリ側の薄い橋渡しである。BEACH 固有の
+長文知識、物理・数値判断、出力解析、可視化 workflow は外部 Codex plugin
+`BEACH Context` (`beach-context`) に委譲する。runops 側では run directory、
+case/survey 展開、manifest、adapter contract、job.sh 生成、lint/test/docs の
+整合性だけを扱う。
 
-- **リポジトリ**: https://github.com/Nkzono99/BEACH
-- **種類**: 境界要素法 (BEM) による表面帯電シミュレーション
-- **言語**: Fortran (コア) + Python (ライブラリ・後処理)
-- **インストール**: `pip install beach-bem`
-- **入力**: TOML 形式 (`beach.toml`)
-- **出力**: CSV ファイル (charges.csv, mesh_triangles.csv 等)
-- **実行**: `beach beach.toml` または `mpirun -np N beach beach.toml`
-- **後処理ツール**: `beachx` コマンド群
+## 最初に確認すること
 
-## 入力ファイル (beach.toml)
+1. 対象 project で `runo plugins --check` または `runo plugins --json` を確認し、
+   `beach-context` 推薦と `delegated_capabilities` を見る。
+2. 現在の session で `BEACH Context` plugin / skill が利用可能なら、
+   `config-review`, `case-design`, `run-diagnose`, `output-analysis`,
+   `visualization-script` はそちらを使う。
+3. plugin が利用できない場合だけ、現在の project files (`case.toml`,
+   `beach.toml`, `manifest.toml`, run output) と upstream docs を根拠にする。
 
-TOML 形式の設定ファイル。主要セクション：
+## runops 側で担当すること
 
-```toml
-[sim]
-dt = 1.4e-8
-batch_count = 10
-max_step = 500
-field_solver = "default"
-box_origin = [0.0, 0.0, 0.0]
-box_size = [1.0, 1.0, 1.0]
+- `src/runops/adapters/contrib/beach/adapter.py` の adapter contract、runtime
+  resolution、required outputs、summary parsing を保つ。
+- `runo create`, `runo submit`, `runo status`, `runo summarize`, `runo collect`
+  から見た runops workflow を壊さない。
+- BEACH project では `runo plugins` が `BEACH Context` / `beach-context` と
+  委譲 role を表示することを確認する。
+- KUDPC 上で実行やテストを行う場合は KUDPC plugin の routing に従い、login node
+  で solver、pytest、可視化、重い解析を直接実行しない。
 
-[[particles.species]]
-name = "electron"
-q_particle = -1.602e-19
-m_particle = 9.109e-31
-temperature_ev = 1.0
-source_mode = "reservoir_face"
+## 最小 fallback
 
-[[particles.species]]
-name = "ion"
-q_particle = 1.602e-19
-m_particle = 9.109e-28
-temperature_ev = 0.1
-source_mode = "reservoir_face"
-
-[mesh]
-mode = "template"
-template = "sphere"
-radius = 0.1
-center = [0.5, 0.5, 0.5]
-
-[output]
-dir = "outputs/latest"
-history_stride = 10
-write_potential_history = true
-```
-
-### CLI ワークフロー
-```bash
-beachx config init          # case.toml をプリセットから生成
-beachx config validate      # 設定の検証
-beachx config render        # case.toml → beach.toml の変換
-beach beach.toml            # シミュレーション実行
-```
-
-## HPC 環境
-
-- Python venv の activate が必要: `source /path/to/venv/bin/activate`
-- venv 自動検出: `resolve_runtime` が cwd から上位ディレクトリを辿って `.venv` を自動検出。`simulators.toml` の `venv_path` が未設定でも動作する
-- module load は不要 (Python パッケージとして完結)
-- MPI 並列対応: `mpirun -np N beach beach.toml` or `srun beach beach.toml`
-
-### 典型的な job.sh
-```bash
-#!/bin/bash
-#SBATCH -p gr10451a
-#SBATCH --rsc p=4:t=1:c=1
-#SBATCH -t 24:00:00
-
-source /path/to/venv/bin/activate
-
-cd work/
-beach beach.toml
-
-# Post-processing
-beachx inspect outputs/latest --save-mesh mesh.png
-beachx coulomb outputs/latest --component z --save coulomb_z.png
-```
-
-## 実行管理タスク
-
-### 入力ファイル生成
-- beach.toml の生成・編集
-- パラメータの検証
-- メッシュ設定の構成
-
-### ジョブ投入
-- job.sh 生成 (venv activation 付き)
-- MPI プロセス数の設定
-
-### 状態監視
-- summary.txt の確認
-- 出力 CSV ファイルの存在チェック
-- エラー検出
-
-## データ処理タスク
-
-### 出力ファイル
-- `summary.txt`: 実行サマリ
-- `charges.csv`: メッシュ要素ごとの電荷分布
-- `mesh_triangles.csv`: メッシュ形状定義（三角形要素）
-- `charge_history.csv`: 電荷の時間発展
-- `potential_history.csv`: 電位の時間発展
-
-### Python API による読み込み
-```python
-from beach import Beach
-
-# 結果の読み込み
-b = Beach("outputs/latest")
-result = b.result
-
-# 電荷データ
-import pandas as pd
-charges = pd.read_csv("outputs/latest/charges.csv")
-mesh = pd.read_csv("outputs/latest/mesh_triangles.csv")
-```
-
-### CSV 直接読み込み
-```python
-import pandas as pd
-import numpy as np
-
-# 電荷分布
-charges = pd.read_csv("work/outputs/latest/charges.csv")
-print(f"Total charge: {charges['charge'].sum():.6e} C")
-print(f"Max charge density: {charges['charge'].max():.6e} C")
-
-# 時間発展
-history = pd.read_csv("work/outputs/latest/charge_history.csv")
-```
-
-## 可視化タスク
-
-### beachx コマンドによる可視化
-```bash
-# メッシュと電荷分布の可視化
-beachx inspect outputs/latest --save-mesh analysis/figures/mesh.png
-
-# アニメーション生成
-beachx animate outputs/latest --quantity potential --save-gif analysis/figures/potential.gif
-
-# クーロン力の可視化
-beachx coulomb outputs/latest --component z --save analysis/figures/coulomb_z.png
-
-# 移動度解析
-beachx mobility outputs/latest --density-kg-m3 2500 --mu-static 0.4
-```
-
-### Python による可視化
-```python
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-
-# 電荷の時間発展
-history = pd.read_csv("work/outputs/latest/charge_history.csv")
-plt.figure(figsize=(10, 6))
-plt.plot(history["step"], history["total_charge"])
-plt.xlabel("Step")
-plt.ylabel("Total Charge (C)")
-plt.title("Charge Accumulation Over Time")
-plt.grid(True)
-plt.savefig("analysis/figures/charge_history.png", dpi=150, bbox_inches="tight")
-
-# 電荷分布のヒートマップ
-charges = pd.read_csv("work/outputs/latest/charges.csv")
-mesh = pd.read_csv("work/outputs/latest/mesh_triangles.csv")
-# 三角形メッシュ上の電荷分布を matplotlib.tri で可視化
-from matplotlib.tri import Triangulation
-# ... (メッシュデータに応じて構成)
-```
-
-### 注意事項
-- BEACH の Python API (`from beach import Beach`) を使うには `beach-bem` パッケージが必要
-- `beachx` コマンドは BEACH インストール時に一緒にインストールされる
-- venv 環境の activate を忘れずに
-- 解析結果は `analysis/` ディレクトリに保存
-- 図は `analysis/figures/` に保存
-
-## コマンド実行時の注意
-
-- BEACH の Python 環境は venv で管理されている
-- プロジェクトルート付近に venv がある想定
-- `source venv/bin/activate` してから Python/beachx コマンドを実行
-- 大量のメッシュデータの処理はメモリに注意
+- 入力は `beach.toml`、runops case は adapter がそれを `work/` に配置する。
+- 代表的な output は `summary.txt`、`charges.csv`、`mesh_triangles.csv`、
+  `charge_history.csv`、`potential_history.csv`。
+- `summary.txt` は runops の完了判定と要約の主な入口である。
+- 詳細な parameter 意味、安定性判断、図化手順は plugin または BEACH upstream
+  docs を根拠にし、この repository の古い記憶で補完しない。

--- a/.claude/agents/emses.md
+++ b/.claude/agents/emses.md
@@ -1,146 +1,45 @@
 ---
 name: emses
-description: "MPIEMSES3D シミュレータの操作エージェント。実行管理、データ処理、可視化を担当する。\n\nExamples:\n\n<example>\nuser: \"EMSES のシミュレーション結果を可視化して\"\nassistant: \"EMSES エージェントを使って可視化を行います。\"\n</example>\n\n<example>\nuser: \"plasma.inp のパラメータを変えて新しい run を作りたい\"\nassistant: \"EMSES エージェントで plasma.inp を生成して run を作成します。\"\n</example>\n\n<example>\nuser: \"EMSES の出力 HDF5 ファイルを解析して\"\nassistant: \"EMSES エージェントで HDF5 データの解析を行います。\"\n</example>"
+description: "MPIEMSES3D を runops から扱うための薄い橋渡しエージェント。入力 review、parameter design、run diagnosis、HDF5/emout output analysis、visualization は MPIEMSES3D Context / emout Context plugin に委譲し、runops 側の run directory、adapter、launcher、manifest、job/harness 整合性を担当する。"
 model: sonnet
 ---
 
-あなたは MPIEMSES3D (3D 電磁 PIC プラズマシミュレータ) の専門エージェントです。
-シミュレーションの実行管理、入力ファイル生成、データ処理、可視化を担当します。
+# EMSES runops bridge
 
-## MPIEMSES3D について
+この agent は runops 開発リポジトリ側の薄い橋渡しである。MPIEMSES3D 固有の
+長文知識、物理・数値判断、`plasma.inp` review、run diagnosis、HDF5/emout
+解析、可視化 workflow は外部 Codex plugin `MPIEMSES3D Context`
+(`mpiemses3d-context`) と `emout Context` (`emout-context`) に委譲する。
+runops 側では run directory、case/survey 展開、manifest、adapter contract、
+launcher/job.sh、lint/test/docs の整合性だけを扱う。
 
-- **リポジトリ**: https://github.com/CS12-Laboratory/MPIEMSES3D
-- **種類**: 3D 電磁粒子シミュレーション (Particle-in-Cell, PIC)
-- **言語**: Fortran + MPI
-- **入力**: Fortran namelist 形式 (`plasma.inp`, optional `plasma.preinp`)
-- **出力**: HDF5 ファイル (`*_0000.h5` 等)、stdout/stderr ログ
-- **実行**: `srun ./mpiemses3D plasma.inp`
+## 最初に確認すること
 
-## 入力ファイル (plasma.inp)
+1. 対象 project で `runo plugins --check` または `runo plugins --json` を確認し、
+   `mpiemses3d-context` / `emout-context` 推薦と `delegated_capabilities` を見る。
+2. 現在の session で external plugin / skill が利用可能なら、
+   `input-review`, `parameter-design`, `run-diagnose`, `output-analysis`,
+   `visualization-script` はそちらを使う。
+3. plugin が利用できない場合だけ、現在の project files (`case.toml`,
+   `plasma.inp`, `manifest.toml`, stdout/HDF5 output) と upstream docs を根拠にする。
 
-Fortran namelist 形式。主要なパラメータ：
+## runops 側で担当すること
 
-```fortran
-&tmgrid
-  nx = 256, ny = 256, nz = 512
-  dt = 1.0e-8
-/
+- `src/runops/adapters/contrib/emses/adapter.py` の adapter contract、runtime
+  resolution、input rendering、required outputs、summary parsing を保つ。
+- launcher / jobgen では Python を MPI rank wrapper にせず、job.sh から
+  `srun` / `mpirun` / `mpiexec` を直接起動する境界を守る。
+- `runo create`, `runo submit`, `runo status`, `runo summarize`, `runo collect`
+  から見た runops workflow を壊さない。
+- EMSES project では `runo plugins` が `MPIEMSES3D Context` と `emout Context`
+  の委譲 role を表示することを確認する。
+- KUDPC 上で実行やテストを行う場合は KUDPC plugin の routing に従い、login node
+  で solver、pytest、可視化、重い解析を直接実行しない。
 
-&jobcon
-  nstep = 10000
-/
+## 最小 fallback
 
-&mpi
-  nodes(1:3) = 4, 4, 8            ! 領域分割 (MPI プロセス数 = 4*4*8 = 128)
-/
-```
-
-主要な namelist グループ: `esorem`, `jobcon`, `digcon`, `plasma`, `tmgrid`, `system`, `mpi`, `intp`, `ptcond`, `gradema`, `dipole`, `emissn`, `inp`, `testch`, `jsrc`, `verbose`
-
-- `&tmgrid`: グリッド定義 (`nx`, `ny`, `nz`, `dt` 等)
-- `&mpi` / `nodes(1:3)`: 各軸の領域分割数。総 MPI プロセス数 = product(nodes)
-- `&jobcon` / `nstep`: 総ステップ数
-- `&plasma`: プラズマパラメータ (`wc`, `phiz` 等)
-
-## HPC 環境
-
-- カスタム Slurm: `#SBATCH --rsc p=N:t=T:c=C`
-- module: `intel/2023.2`, `intelmpi/2023.2`, `hdf5/1.12.2_intel-2023.2-impi`, `fftw/3.3.10_intel-2022.3-impi`
-- 前処理: `preinp` コマンド (plasma.preinp がある場合)
-- 後処理: `mypython plot.py ./`, `mypython plot_hole.py ./`
-- sbatch ラッパー: `mysbatch job.sh` (plasma.inp から自動的にプロセス数を設定)
-- venv 自動検出: `resolve_runtime` が cwd から上位ディレクトリを辿って `.venv` を自動検出。`simulators.toml` の `venv_path` が未設定でも動作する
-
-## 実行管理タスク
-
-### 入力ファイル生成
-- Fortran namelist のパース・生成
-- パラメータの変更・検証
-- 領域分割の最適化提案（nxs, nys, nzs の組み合わせ）
-
-### ジョブ投入
-- job.sh 生成（rsc モード、module load 付き）
-- プロセス数の自動計算: `&mpi` グループの `nodes(1:3)` から product(nodes) で算出
-- walltime の見積もり
-
-### 状態監視
-- stdout ログの解析（タイムステップ進捗）
-- HDF5 出力の確認
-- エラー検出
-
-## データ処理タスク
-
-### HDF5 データ読み込み (emout 推奨)
-```python
-import emout
-
-# emout による読み込み (単位変換対応)
-data = emout.Emses("work/")
-phi = data.phisp[0]  # 電位 (タイムステップ 0)
-nd1 = data.nd1p[0]   # 粒子密度 (種1)
-```
-
-### HDF5 直接読み込み
-```python
-import h5py
-import numpy as np
-
-with h5py.File("work/phisp00_0000.h5", "r") as f:
-    data = f[list(f.keys())[0]][:]
-```
-
-### 典型的な出力ファイル
-- `phisp00_0000.h5`: 電位
-- `nd1p00_0000.h5`, `nd2p00_0000.h5`: 粒子数密度 (種ごと)
-- `rho00_0000.h5`: 電荷密度
-- `ex00_0000.h5`, `ey00_0000.h5`, `ez00_0000.h5`: 電場
-- `bz00_0000.h5` 等: 磁場
-- `j1x00_0000.h5`, `j1y00_0000.h5`, `j1z00_0000.h5`: 電流密度
-- `p4xe00_0000.h5` 等: 粒子位置・速度 (粒子種ごと)
-- ファイル名の `00` はリージョン番号、`0000` はタイムステップ
-
-### 関連 Python パッケージ
-- `emout`: EMSES 出力 HDF5 の読み込み・単位変換 (`pip install emout`)
-- `camptools`: ワークフロー管理・パラメータスイープ (`pip install camptools`)
-- `preinp`: Fortran namelist 前処理ツール (`pip install preinp`)
-
-## 可視化タスク
-
-### 2D スライス
-```python
-import matplotlib.pyplot as plt
-import h5py
-
-with h5py.File("work/phi_0000.h5", "r") as f:
-    phi = f["phi"][:]
-
-# XY 平面のスライス
-plt.figure(figsize=(10, 8))
-plt.pcolormesh(phi[:, :, phi.shape[2]//2].T, cmap="RdBu_r")
-plt.colorbar(label="Potential")
-plt.xlabel("X")
-plt.ylabel("Y")
-plt.title("Electrostatic Potential (XY plane)")
-plt.savefig("analysis/figures/phi_xy.png", dpi=150, bbox_inches="tight")
-```
-
-### 時間発展
-```python
-import glob
-import re
-
-# タイムステップごとのファイルをソート
-files = sorted(glob.glob("work/phi_*.h5"), key=lambda f: int(re.search(r'(\d+)\.h5', f).group(1)))
-```
-
-### 注意事項
-- HDF5 ファイルは大容量になりうる。メモリに注意
-- `mypython` は環境固有のコマンド。標準 Python で代替する場合は `h5py` + `matplotlib` を使用
-- 解析結果は `analysis/` ディレクトリに保存
-- 図は `analysis/figures/` に保存
-
-## コマンド実行時の注意
-
-- `uv run` でプロジェクトの Python 環境を使用
-- HDF5 の読み書きには `h5py` が必要（別途インストール）
-- 大容量データの処理はメモリを考慮して chunk 単位で処理
+- 代表入力は `plasma.inp` と optional `plasma.preinp`。
+- 代表 output は stdout/stderr log と `*_0000.h5` 系 HDF5 files。
+- runops の状態追跡は `manifest.toml` と adapter output detection を正本にする。
+- 詳細な namelist 意味、安定性判断、emout API、図化手順は plugin または upstream
+  docs を根拠にし、この repository の古い記憶で補完しない。

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -10,7 +10,8 @@
 | `runops setup [URL] [--with-refs]` | 既存プロジェクトを clone + 環境セットアップ (refs mirror は opt-in) |
 | `runops doctor` | 環境検査 |
 | `runops context --json` | Agent 向け project context を JSON で取得 |
-| `runops lint [PATH] [--scope ...]` | project state の health check |
+| `runops plugins [--json] [--check] [--strict]` | project / simulator / site に基づく推奨 Codex plugins を表示・メタデータ検査 |
+| `runops lint [PATH] [--scope ...]` | project state と推奨 plugin metadata の health check |
 | `runops migrate list/show/apply` | project-state migration の確認・適用 |
 | `runops mcp serve --transport stdio` | MCP provider を stdio で起動 |
 | `runops mcp serve --transport streamable-http` | MCP provider を Streamable HTTP で起動 |

--- a/.claude/rules/knowledge-layer.md
+++ b/.claude/rules/knowledge-layer.md
@@ -31,6 +31,10 @@ AI エージェントがシミュレーションを自律的に行うための�
 Simulator / site が外部 Codex plugin を推薦する場合、`runops init` / `runops setup`
 と生成 harness に導線を出す。plugin install / enable はユーザー local な Codex
 環境の操作であり、runops project state には含めない。
+開発ハーネス内の `.claude/agents/emses.md`, `.claude/agents/beach.md`,
+`.agents/skills/emses`, `.agents/skills/beach` は runops 側の薄い橋渡しに保ち、
+シミュレータ固有の長文 context は MPIEMSES3D / emout / BEACH などの外部 plugin
+へ委譲する。
 
 ```bash
 runops knowledge source attach git shared-kb git@github.com:lab/hpc-shared-knowledge.git

--- a/.codex/agents/beach.toml
+++ b/.codex/agents/beach.toml
@@ -1,213 +1,58 @@
 description = """
-BEACH (BEM + Accumulated CHarge) シミュレータの操作エージェント。実行管理、データ処理、可視化を担当する。
+BEACH を runops から扱うための薄い橋渡しエージェント。BEACH 固有の config review、case design、diagnosis、output analysis、visualization は BEACH Context plugin に委譲し、runops 側の run directory、adapter、manifest、job/harness 整合性を担当する。
 
 Examples:
 
 <example>
 user: "BEACH のシミュレーション結果を可視化して"
-assistant: "BEACH エージェントを使って可視化を行います。"
+assistant: "BEACH Context plugin が利用可能なら解析・可視化判断をそちらに委譲し、runops 側では対象 run と output path を確認します。"
 </example>
 
 <example>
 user: "beach.toml のパラメータを変えて新しい run を作りたい"
-assistant: "BEACH エージェントで beach.toml を生成して run を作成します。"
+assistant: "BEACH 固有の parameter design は BEACH Context plugin に委譲し、runops 側では case 展開と run 作成の流れを扱います。"
 </example>
 
 <example>
-user: "BEACH の電荷分布を解析して"
-assistant: "BEACH エージェントで charges.csv の解析を行います。"
+user: "BEACH project の plugin 推薦が出ているか確認して"
+assistant: "`runo plugins --check` と `delegated_capabilities` を確認します。"
 </example>"""
 developer_instructions = """
-あなたは BEACH (BEM + Accumulated CHarge) シミュレータの専門エージェントです。
-境界要素法による表面帯電シミュレーションの実行管理、データ処理、可視化を担当します。
+# BEACH runops bridge
 
-## BEACH について
+この agent は runops 開発リポジトリ側の薄い橋渡しである。BEACH 固有の
+長文知識、物理・数値判断、出力解析、可視化 workflow は外部 Codex plugin
+`BEACH Context` (`beach-context`) に委譲する。runops 側では run directory、
+case/survey 展開、manifest、adapter contract、job.sh 生成、lint/test/docs の
+整合性だけを扱う。
 
-- **リポジトリ**: https://github.com/Nkzono99/BEACH
-- **種類**: 境界要素法 (BEM) による表面帯電シミュレーション
-- **言語**: Fortran (コア) + Python (ライブラリ・後処理)
-- **インストール**: `pip install beach-bem`
-- **入力**: TOML 形式 (`beach.toml`)
-- **出力**: CSV ファイル (charges.csv, mesh_triangles.csv 等)
-- **実行**: `beach beach.toml` または `mpirun -np N beach beach.toml`
-- **後処理ツール**: `beachx` コマンド群
+## 最初に確認すること
 
-## 入力ファイル (beach.toml)
+1. 対象 project で `runo plugins --check` または `runo plugins --json` を確認し、
+   `beach-context` 推薦と `delegated_capabilities` を見る。
+2. 現在の Codex session で `BEACH Context` plugin / skill が利用可能なら、
+   `config-review`, `case-design`, `run-diagnose`, `output-analysis`,
+   `visualization-script` はそちらを使う。
+3. plugin が利用できない場合だけ、現在の project files (`case.toml`,
+   `beach.toml`, `manifest.toml`, run output) と upstream docs を根拠にする。
 
-TOML 形式の設定ファイル。主要セクション：
+## runops 側で担当すること
 
-```toml
-[sim]
-dt = 1.4e-8
-batch_count = 10
-max_step = 500
-field_solver = "default"
-box_origin = [0.0, 0.0, 0.0]
-box_size = [1.0, 1.0, 1.0]
+- `src/runops/adapters/contrib/beach/adapter.py` の adapter contract、runtime
+  resolution、required outputs、summary parsing を保つ。
+- `runo create`, `runo submit`, `runo status`, `runo summarize`, `runo collect`
+  から見た runops workflow を壊さない。
+- BEACH project では `runo plugins` が `BEACH Context` / `beach-context` と
+  委譲 role を表示することを確認する。
+- KUDPC 上で実行やテストを行う場合は KUDPC plugin の routing に従い、login node
+  で solver、pytest、可視化、重い解析を直接実行しない。
 
-[[particles.species]]
-name = "electron"
-q_particle = -1.602e-19
-m_particle = 9.109e-31
-temperature_ev = 1.0
-source_mode = "reservoir_face"
+## 最小 fallback
 
-[[particles.species]]
-name = "ion"
-q_particle = 1.602e-19
-m_particle = 9.109e-28
-temperature_ev = 0.1
-source_mode = "reservoir_face"
-
-[mesh]
-mode = "template"
-template = "sphere"
-radius = 0.1
-center = [0.5, 0.5, 0.5]
-
-[output]
-dir = "outputs/latest"
-history_stride = 10
-write_potential_history = true
-```
-
-### CLI ワークフロー
-```bash
-beachx config init          # case.toml をプリセットから生成
-beachx config validate      # 設定の検証
-beachx config render        # case.toml → beach.toml の変換
-beach beach.toml            # シミュレーション実行
-```
-
-## HPC 環境
-
-- Python venv の activate が必要: `source /path/to/venv/bin/activate`
-- venv 自動検出: `resolve_runtime` が cwd から上位ディレクトリを辿って `.venv` を自動検出。`simulators.toml` の `venv_path` が未設定でも動作する
-- module load は不要 (Python パッケージとして完結)
-- MPI 並列対応: `mpirun -np N beach beach.toml` or `srun beach beach.toml`
-
-### 典型的な job.sh
-```bash
-#!/bin/bash
-#SBATCH -p gr10451a
-#SBATCH --rsc p=4:t=1:c=1
-#SBATCH -t 24:00:00
-
-source /path/to/venv/bin/activate
-
-cd work/
-beach beach.toml
-
-# Post-processing
-beachx inspect outputs/latest --save-mesh mesh.png
-beachx coulomb outputs/latest --component z --save coulomb_z.png
-```
-
-## 実行管理タスク
-
-### 入力ファイル生成
-- beach.toml の生成・編集
-- パラメータの検証
-- メッシュ設定の構成
-
-### ジョブ投入
-- job.sh 生成 (venv activation 付き)
-- MPI プロセス数の設定
-
-### 状態監視
-- summary.txt の確認
-- 出力 CSV ファイルの存在チェック
-- エラー検出
-
-## データ処理タスク
-
-### 出力ファイル
-- `summary.txt`: 実行サマリ
-- `charges.csv`: メッシュ要素ごとの電荷分布
-- `mesh_triangles.csv`: メッシュ形状定義（三角形要素）
-- `charge_history.csv`: 電荷の時間発展
-- `potential_history.csv`: 電位の時間発展
-
-### Python API による読み込み
-```python
-from beach import Beach
-
-# 結果の読み込み
-b = Beach("outputs/latest")
-result = b.result
-
-# 電荷データ
-import pandas as pd
-charges = pd.read_csv("outputs/latest/charges.csv")
-mesh = pd.read_csv("outputs/latest/mesh_triangles.csv")
-```
-
-### CSV 直接読み込み
-```python
-import pandas as pd
-import numpy as np
-
-# 電荷分布
-charges = pd.read_csv("work/outputs/latest/charges.csv")
-print(f"Total charge: {charges['charge'].sum():.6e} C")
-print(f"Max charge density: {charges['charge'].max():.6e} C")
-
-# 時間発展
-history = pd.read_csv("work/outputs/latest/charge_history.csv")
-```
-
-## 可視化タスク
-
-### beachx コマンドによる可視化
-```bash
-# メッシュと電荷分布の可視化
-beachx inspect outputs/latest --save-mesh analysis/figures/mesh.png
-
-# アニメーション生成
-beachx animate outputs/latest --quantity potential --save-gif analysis/figures/potential.gif
-
-# クーロン力の可視化
-beachx coulomb outputs/latest --component z --save analysis/figures/coulomb_z.png
-
-# 移動度解析
-beachx mobility outputs/latest --density-kg-m3 2500 --mu-static 0.4
-```
-
-### Python による可視化
-```python
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-
-# 電荷の時間発展
-history = pd.read_csv("work/outputs/latest/charge_history.csv")
-plt.figure(figsize=(10, 6))
-plt.plot(history["step"], history["total_charge"])
-plt.xlabel("Step")
-plt.ylabel("Total Charge (C)")
-plt.title("Charge Accumulation Over Time")
-plt.grid(True)
-plt.savefig("analysis/figures/charge_history.png", dpi=150, bbox_inches="tight")
-
-# 電荷分布のヒートマップ
-charges = pd.read_csv("work/outputs/latest/charges.csv")
-mesh = pd.read_csv("work/outputs/latest/mesh_triangles.csv")
-# 三角形メッシュ上の電荷分布を matplotlib.tri で可視化
-from matplotlib.tri import Triangulation
-# ... (メッシュデータに応じて構成)
-```
-
-### 注意事項
-- BEACH の Python API (`from beach import Beach`) を使うには `beach-bem` パッケージが必要
-- `beachx` コマンドは BEACH インストール時に一緒にインストールされる
-- venv 環境の activate を忘れずに
-- 解析結果は `analysis/` ディレクトリに保存
-- 図は `analysis/figures/` に保存
-
-## コマンド実行時の注意
-
-- BEACH の Python 環境は venv で管理されている
-- プロジェクトルート付近に venv がある想定
-- `source venv/bin/activate` してから Python/beachx コマンドを実行
-- 大量のメッシュデータの処理はメモリに注意"""
-name = "beach"
+- 入力は `beach.toml`、runops case は adapter がそれを `work/` に配置する。
+- 代表的な output は `summary.txt`、`charges.csv`、`mesh_triangles.csv`、
+  `charge_history.csv`、`potential_history.csv`。
+- `summary.txt` は runops の完了判定と要約の主な入口である。
+- 詳細な parameter 意味、安定性判断、図化手順は plugin または BEACH upstream
+  docs を根拠にし、この repository の古い記憶で補完しない。
+"""

--- a/.codex/agents/emses.toml
+++ b/.codex/agents/emses.toml
@@ -1,161 +1,60 @@
 description = """
-MPIEMSES3D シミュレータの操作エージェント。実行管理、データ処理、可視化を担当する。
+MPIEMSES3D を runops から扱うための薄い橋渡しエージェント。入力 review、parameter design、run diagnosis、HDF5/emout output analysis、visualization は MPIEMSES3D Context / emout Context plugin に委譲し、runops 側の run directory、adapter、launcher、manifest、job/harness 整合性を担当する。
 
 Examples:
 
 <example>
 user: "EMSES のシミュレーション結果を可視化して"
-assistant: "EMSES エージェントを使って可視化を行います。"
+assistant: "emout Context plugin が利用可能なら解析・可視化判断をそちらに委譲し、runops 側では対象 run と output path を確認します。"
 </example>
 
 <example>
 user: "plasma.inp のパラメータを変えて新しい run を作りたい"
-assistant: "EMSES エージェントで plasma.inp を生成して run を作成します。"
+assistant: "MPIEMSES3D 固有の parameter design は MPIEMSES3D Context plugin に委譲し、runops 側では case 展開と run 作成の流れを扱います。"
 </example>
 
 <example>
-user: "EMSES の出力 HDF5 ファイルを解析して"
-assistant: "EMSES エージェントで HDF5 データの解析を行います。"
+user: "EMSES project の plugin 推薦が出ているか確認して"
+assistant: "`runo plugins --check` と `delegated_capabilities` を確認します。"
 </example>"""
-developer_instructions = '''
-あなたは MPIEMSES3D (3D 電磁 PIC プラズマシミュレータ) の専門エージェントです。
-シミュレーションの実行管理、入力ファイル生成、データ処理、可視化を担当します。
+developer_instructions = """
+# EMSES runops bridge
 
-## MPIEMSES3D について
+この agent は runops 開発リポジトリ側の薄い橋渡しである。MPIEMSES3D 固有の
+長文知識、物理・数値判断、`plasma.inp` review、run diagnosis、HDF5/emout
+解析、可視化 workflow は外部 Codex plugin `MPIEMSES3D Context`
+(`mpiemses3d-context`) と `emout Context` (`emout-context`) に委譲する。
+runops 側では run directory、case/survey 展開、manifest、adapter contract、
+launcher/job.sh、lint/test/docs の整合性だけを扱う。
 
-- **リポジトリ**: https://github.com/CS12-Laboratory/MPIEMSES3D
-- **種類**: 3D 電磁粒子シミュレーション (Particle-in-Cell, PIC)
-- **言語**: Fortran + MPI
-- **入力**: Fortran namelist 形式 (`plasma.inp`, optional `plasma.preinp`)
-- **出力**: HDF5 ファイル (`*_0000.h5` 等)、stdout/stderr ログ
-- **実行**: `srun ./mpiemses3D plasma.inp`
+## 最初に確認すること
 
-## 入力ファイル (plasma.inp)
+1. 対象 project で `runo plugins --check` または `runo plugins --json` を確認し、
+   `mpiemses3d-context` / `emout-context` 推薦と `delegated_capabilities` を見る。
+2. 現在の Codex session で external plugin / skill が利用可能なら、
+   `input-review`, `parameter-design`, `run-diagnose`, `output-analysis`,
+   `visualization-script` はそちらを使う。
+3. plugin が利用できない場合だけ、現在の project files (`case.toml`,
+   `plasma.inp`, `manifest.toml`, stdout/HDF5 output) と upstream docs を根拠にする。
 
-Fortran namelist 形式。主要なパラメータ：
+## runops 側で担当すること
 
-```fortran
-&tmgrid
-  nx = 256, ny = 256, nz = 512
-  dt = 1.0e-8
-/
+- `src/runops/adapters/contrib/emses/adapter.py` の adapter contract、runtime
+  resolution、input rendering、required outputs、summary parsing を保つ。
+- launcher / jobgen では Python を MPI rank wrapper にせず、job.sh から
+  `srun` / `mpirun` / `mpiexec` を直接起動する境界を守る。
+- `runo create`, `runo submit`, `runo status`, `runo summarize`, `runo collect`
+  から見た runops workflow を壊さない。
+- EMSES project では `runo plugins` が `MPIEMSES3D Context` と `emout Context`
+  の委譲 role を表示することを確認する。
+- KUDPC 上で実行やテストを行う場合は KUDPC plugin の routing に従い、login node
+  で solver、pytest、可視化、重い解析を直接実行しない。
 
-&jobcon
-  nstep = 10000
-/
+## 最小 fallback
 
-&mpi
-  nodes(1:3) = 4, 4, 8            ! 領域分割 (MPI プロセス数 = 4*4*8 = 128)
-/
-```
-
-主要な namelist グループ: `esorem`, `jobcon`, `digcon`, `plasma`, `tmgrid`, `system`, `mpi`, `intp`, `ptcond`, `gradema`, `dipole`, `emissn`, `inp`, `testch`, `jsrc`, `verbose`
-
-- `&tmgrid`: グリッド定義 (`nx`, `ny`, `nz`, `dt` 等)
-- `&mpi` / `nodes(1:3)`: 各軸の領域分割数。総 MPI プロセス数 = product(nodes)
-- `&jobcon` / `nstep`: 総ステップ数
-- `&plasma`: プラズマパラメータ (`wc`, `phiz` 等)
-
-## HPC 環境
-
-- カスタム Slurm: `#SBATCH --rsc p=N:t=T:c=C`
-- module: `intel/2023.2`, `intelmpi/2023.2`, `hdf5/1.12.2_intel-2023.2-impi`, `fftw/3.3.10_intel-2022.3-impi`
-- 前処理: `preinp` コマンド (plasma.preinp がある場合)
-- 後処理: `mypython plot.py ./`, `mypython plot_hole.py ./`
-- sbatch ラッパー: `mysbatch job.sh` (plasma.inp から自動的にプロセス数を設定)
-- venv 自動検出: `resolve_runtime` が cwd から上位ディレクトリを辿って `.venv` を自動検出。`simulators.toml` の `venv_path` が未設定でも動作する
-
-## 実行管理タスク
-
-### 入力ファイル生成
-- Fortran namelist のパース・生成
-- パラメータの変更・検証
-- 領域分割の最適化提案（nxs, nys, nzs の組み合わせ）
-
-### ジョブ投入
-- job.sh 生成（rsc モード、module load 付き）
-- プロセス数の自動計算: `&mpi` グループの `nodes(1:3)` から product(nodes) で算出
-- walltime の見積もり
-
-### 状態監視
-- stdout ログの解析（タイムステップ進捗）
-- HDF5 出力の確認
-- エラー検出
-
-## データ処理タスク
-
-### HDF5 データ読み込み (emout 推奨)
-```python
-import emout
-
-# emout による読み込み (単位変換対応)
-data = emout.Emses("work/")
-phi = data.phisp[0]  # 電位 (タイムステップ 0)
-nd1 = data.nd1p[0]   # 粒子密度 (種1)
-```
-
-### HDF5 直接読み込み
-```python
-import h5py
-import numpy as np
-
-with h5py.File("work/phisp00_0000.h5", "r") as f:
-    data = f[list(f.keys())[0]][:]
-```
-
-### 典型的な出力ファイル
-- `phisp00_0000.h5`: 電位
-- `nd1p00_0000.h5`, `nd2p00_0000.h5`: 粒子数密度 (種ごと)
-- `rho00_0000.h5`: 電荷密度
-- `ex00_0000.h5`, `ey00_0000.h5`, `ez00_0000.h5`: 電場
-- `bz00_0000.h5` 等: 磁場
-- `j1x00_0000.h5`, `j1y00_0000.h5`, `j1z00_0000.h5`: 電流密度
-- `p4xe00_0000.h5` 等: 粒子位置・速度 (粒子種ごと)
-- ファイル名の `00` はリージョン番号、`0000` はタイムステップ
-
-### 関連 Python パッケージ
-- `emout`: EMSES 出力 HDF5 の読み込み・単位変換 (`pip install emout`)
-- `camptools`: ワークフロー管理・パラメータスイープ (`pip install camptools`)
-- `preinp`: Fortran namelist 前処理ツール (`pip install preinp`)
-
-## 可視化タスク
-
-### 2D スライス
-```python
-import matplotlib.pyplot as plt
-import h5py
-
-with h5py.File("work/phi_0000.h5", "r") as f:
-    phi = f["phi"][:]
-
-# XY 平面のスライス
-plt.figure(figsize=(10, 8))
-plt.pcolormesh(phi[:, :, phi.shape[2]//2].T, cmap="RdBu_r")
-plt.colorbar(label="Potential")
-plt.xlabel("X")
-plt.ylabel("Y")
-plt.title("Electrostatic Potential (XY plane)")
-plt.savefig("analysis/figures/phi_xy.png", dpi=150, bbox_inches="tight")
-```
-
-### 時間発展
-```python
-import glob
-import re
-
-# タイムステップごとのファイルをソート
-files = sorted(glob.glob("work/phi_*.h5"), key=lambda f: int(re.search(r'(\d+)\.h5', f).group(1)))
-```
-
-### 注意事項
-- HDF5 ファイルは大容量になりうる。メモリに注意
-- `mypython` は環境固有のコマンド。標準 Python で代替する場合は `h5py` + `matplotlib` を使用
-- 解析結果は `analysis/` ディレクトリに保存
-- 図は `analysis/figures/` に保存
-
-## コマンド実行時の注意
-
-- `uv run` でプロジェクトの Python 環境を使用
-- HDF5 の読み書きには `h5py` が必要（別途インストール）
-- 大容量データの処理はメモリを考慮して chunk 単位で処理'''
-name = "emses"
+- 代表入力は `plasma.inp` と optional `plasma.preinp`。
+- 代表 output は stdout/stderr log と `*_0000.h5` 系 HDF5 files。
+- runops の状態追跡は `manifest.toml` と adapter output detection を正本にする。
+- 詳細な namelist 意味、安定性判断、emout API、図化手順は plugin または upstream
+  docs を根拠にし、この repository の古い記憶で補完しない。
+"""

--- a/.codex/rules/commands.md
+++ b/.codex/rules/commands.md
@@ -11,7 +11,8 @@
 | `runo setup [URL] [--with-refs]` | 既存プロジェクトを clone + 環境セットアップ (refs mirror は opt-in) |
 | `runo doctor` | 環境検査 |
 | `runo context --json` | Agent 向け project context を JSON で取得 |
-| `runo lint [PATH] [--scope ...]` | project state の health check |
+| `runo plugins [--json] [--check] [--strict]` | project / simulator / site に基づく推奨 Codex plugins を表示・メタデータ検査 |
+| `runo lint [PATH] [--scope ...]` | project state と推奨 plugin metadata の health check |
 | `runo migrate list/show/apply` | project-state migration の確認・適用 |
 | `runo mcp serve --transport stdio` | MCP provider を stdio で起動 |
 | `runo mcp serve --transport streamable-http` | MCP provider を Streamable HTTP で起動 |

--- a/.codex/rules/knowledge-layer.md
+++ b/.codex/rules/knowledge-layer.md
@@ -31,6 +31,10 @@ AI エージェントがシミュレーションを自律的に行うための�
 Simulator / site が外部 Codex plugin を推薦する場合、`runo init` / `runo setup`
 と生成 harness に導線を出す。plugin install / enable はユーザー local な Codex
 環境の操作であり、runops project state には含めない。
+開発ハーネス内の `.agents/skills/emses`, `.agents/skills/beach`,
+`.codex/agents/emses.toml`, `.codex/agents/beach.toml` は runops 側の薄い
+橋渡しに保ち、シミュレータ固有の長文 context は MPIEMSES3D / emout / BEACH
+などの外部 plugin へ委譲する。
 
 ```bash
 runo knowledge source attach git shared-kb git@github.com:lab/hpc-shared-knowledge.git

--- a/docs/agent-user-guide.md
+++ b/docs/agent-user-guide.md
@@ -18,7 +18,7 @@ project 側では `.runops/knowledge/runops/agent-user-guide.md` と
 |------|---------|
 | version 確認 | `runo --version` |
 | プロジェクト状況把握 | `runo context --json` (`research_agenda` / latest note を含む) |
-| project health check | `runo lint --scope structure,analysis,knowledge` |
+| project health check | `runo lint --scope structure,analysis,knowledge,plugins` |
 | case テンプレート生成 | `runo case new <name>` |
 | 最小 case テンプレート生成 | `runo case new <name> --minimal` |
 | survey 付き case 生成 | `runo case new <name> --survey` |
@@ -110,7 +110,7 @@ release note / migration guide を読み、定型 migration は
 `runo migrate apply M0-0001 --dry-run` → `runo migrate apply M0-0001` で適用する。
 CLI 未対応または判断が必要なものは `migrate-runops` skill で扱い、適用 / skip / defer を
 `notes/YYYY-MM-DD.md` に記録する。
-更新後や大きな handoff 前は `runo lint` で project state の読みやすさを確認する。
+更新後や大きな handoff 前は `runo lint` で project state と推奨 plugin metadata の読みやすさを確認する。
 
 Python package の構造整理、module 分割、循環 import 解消、packaging 整理などは
 `python-package-refactor` skill を使う。`scripts/` と `references/` 付きで

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -648,7 +648,9 @@ adapter.required_outputs() ← analysis-ready に必要な成果物
 ```
 
 - simulator/environment plugin: 長文の Agent context、環境スキル、解析ライブラリ利用法
-- `codex_plugins()`: simulator に推奨する外部 Codex plugin の導入導線
+- `codex_plugins()`: simulator に推奨する外部 Codex plugin の導入導線と委譲役割 (`capabilities`)
+- `runo plugins`: project / simulator / site から推薦 plugin を再表示・JSON 出力し、推薦メタデータを検査する監査入口
+- `runo doctor`: 推薦メタデータの error も project 健全性として検出するが、plugin の install 状態は管理しない
 - `refs/`: `runo init --with-refs` または手動 clone で使う任意のローカル mirror
 - `doc_repos()` / `knowledge_sources()`: 任意 mirror を使う場合の clone 先とインデックス対象
 - `parameter_schema()`: 型・単位・範囲・制約・導出公式
@@ -658,6 +660,8 @@ adapter.required_outputs() ← analysis-ready に必要な成果物
 シミュレータ固有の Agent 向け長文コンテキストは、runops adapter ではなく各
 シミュレータや解析ライブラリの Codex plugin に置く。runops adapter は実行管理に
 必要なテンプレート、検証、入出力検出、provenance に責務を限定する。
+adapter が返す package-bundled `agent_guide()` は、plugin や明示的 knowledge source が
+ない場合の runops 側 fallback に限定し、完全な simulator manual にしない。
 
 ### 実行環境知識
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -92,6 +92,12 @@ my_solver = "my_solver_runops.adapter:MySolverAdapter"
 entry point 名 (`my_solver`) が `simulators.toml` の `adapter` 値です。runops は
 `simulators.toml` 読み込み時にこの entry point を探し、見つからない場合だけ
 同梱 contrib module の import 規約へ fallback します。
+外部 adapter が未導入の project では、`runo plugins --check` と
+MCP `runops.project.plugins` が plugin 推薦を収集できなかったことを warning として
+返します。runops は adapter や Codex plugin を自動 install しません。
+project 固有の plugin 推薦だけを足したい場合は、adapter package を変更せず
+simulator に紐づくものは `[simulators.<name>.codex_plugins.<plugin>]`、project
+全体に紐づくものは `[project.codex_plugins.<plugin>]` に metadata を書けます。
 
 ### ステップ 2: 7 つのメソッドの実装
 
@@ -876,7 +882,9 @@ cookbook の規約は `docs/simulator-kb-spec.md` を参照。
 
 simulator 固有の長文 context や解析 workflow を外部 Codex plugin に置く場合、
 Adapter は plugin の導入導線だけを返す。runops は plugin を自動 install せず、
-`runo init` / `runo setup` の出力と生成 harness に推奨として表示する:
+`runo init` / `runo setup` の出力、`runo plugins`、生成 harness に推奨として表示する。
+既存 project の harness 更新では adapter / simulator config / project config / site
+profile から組み立てた同じ plugin inventory を使う:
 
 ```python
 from runops.core.codex_plugin import CodexPluginRecommendation
@@ -888,6 +896,12 @@ def codex_plugins(cls) -> list[CodexPluginRecommendation]:
             name="my-simulator-context",
             display_name="My Simulator Context",
             reason="Input review, parameter design, run diagnosis, and output analysis.",
+            capabilities=(
+                "input-review",
+                "parameter-design",
+                "run-diagnose",
+                "output-analysis",
+            ),
             install_hint=(
                 "codex plugin marketplace add owner/my-simulator --ref main "
                 "--sparse .agents/plugins --sparse plugins/my-simulator-context\n"
@@ -901,6 +915,28 @@ def codex_plugins(cls) -> list[CodexPluginRecommendation]:
 private repo や site-local plugin の場合は `visibility="private-or-gated"` とし、
 `install_hint` に GitHub 認証、ローカル checkout marketplace、または利用者が環境
 skill を自作する fallback を書く。
+Adapter の `codex_plugins()` は project context がなくても利用できる完全な
+`CodexPluginRecommendation` を返す。`name`, `display_name`, `reason`,
+`install_hint` を空にせず、`visibility` は `"public"` または
+`"private-or-gated"` を使い、`source` には `simulator:<name>` を入れる。
+`capabilities` には `"input-review"`、`"run-diagnose"`、`"output-analysis"`、
+`"cookbook"` など、runops 本体から plugin へ委譲する役割ラベルを入れる。
+project / simulator / site の TOML では配列を推奨し、単一 role は文字列でもよい。
+TOML table や空文字列配列など、role label として読めない値は warning になる。
+組み込み Adapter は contract test でこの metadata を検査する。
+同じ plugin 名を Adapter / simulator config / project config / site profile の複数
+レイヤから推薦する場合、表示名、導入手順、visibility などの実体メタデータは最初の
+推薦を使い、`source` と `capabilities` は統合する。これにより adapter package を
+変更せず、site や project 側で委譲役割だけを追加できる。JSON payload では互換用の
+`source` 文字列に加えて、parse 済みの `sources` 配列も返す。`runo plugins --check`
+と MCP `runops.project.plugins` は、表示名や導入手順などが食い違う重複推薦を
+warning として報告する。
+
+`agent_guide()` を実装する場合も、plugin や明示的 knowledge source が使えない時の
+最小 fallback に留める。parameter design、input review、run diagnosis、output
+analysis、visualization などの長文 workflow は plugin 側へ置き、`agent_guide()` は
+runops の run directory / manifest / adapter boundary と推薦 plugin の確認手順を
+示す程度にする。
 
 ### campaign.toml との連携
 

--- a/docs/get-started-with-agent.md
+++ b/docs/get-started-with-agent.md
@@ -15,11 +15,18 @@ interface です。人間は研究意図、制約、確認、解釈に集中し�
 2. **ベース入力の方針** — 既存の入力テンプレート、plugin/knowledge source、手元の資料のどれを起点に組み立てるか
 
 `runo init` では通常、simulator や launcher の設定を対話的に選ぶため、最初の依頼でそれらを毎回書き直す必要はありません。
-選んだ simulator / site に外部 Codex plugin がある場合、`runo init` と
+project / simulator / site に外部 Codex plugin 推薦がある場合、`runo init` と
 生成される `AGENTS.md` / `CLAUDE.md` に推奨 plugin と導入手順が表示されます。
 たとえば `emses` では MPIEMSES3D / emout の plugin、`camphor` site profile では
-KUDPC HPC plugin が案内されます。runops は plugin を自動 install せず、
+KUDPC HPC plugin、`beach` では BEACH Context plugin が案内されます。
+既存 project では `runo setup` の出力と `runo update-harness` が
+`[project.codex_plugins]` も含めた同じ推薦 inventory を使うため、project 固有の
+解析 workflow や handoff plugin も生成 harness に反映できます。
+runops は plugin を自動 install せず、
 ユーザーの Codex 環境で `/plugins` や `codex plugin ...` により有効化します。
+既存 project で推薦を確認したい場合は `runo plugins`、agent や外部 tool から
+読む場合は `runo plugins --json` を使います。`runo plugins --check` は推薦
+メタデータの欠落を検査しますが、user-local な plugin install 状態は検査しません。
 
 ベース入力ファイル (`plasma.toml`, `beach.toml` など) を明示すると意図が伝わりやすくなります。
 一方で、まだベースを決めていない場合でも、Agent は simulator/environment plugin、
@@ -36,6 +43,7 @@ docs/cookbook を順に確認し、入力例や推奨パラメータをもとに
 ```bash
 uvx --from runops runo init
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 既存プロジェクトをセットアップする場合:
@@ -44,6 +52,7 @@ uvx --from runops runo doctor
 uvx --from runops runo setup https://github.com/user/my-project.git
 cd my-project
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 `runo init` がディレクトリ構造と初期ファイルを作ります。

--- a/docs/layers/interface.md
+++ b/docs/layers/interface.md
@@ -91,10 +91,10 @@ uvx --from runops runo doctor
 |---------|------|
 | `runo init [SIMS...] [-y] [--with-refs]` | プロジェクトの初期化。対話型がデフォルト、refs mirror は opt-in |
 | `runo setup [URL] [--with-refs]` | 既存 runops project の clone + セットアップ。refs mirror は opt-in |
-| `runo doctor [PATH]` | 環境検査。設定、sbatch、run_id 一意性、環境検出を確認 |
+| `runo doctor [PATH]` | 環境検査。設定、sbatch、run_id 一意性、環境検出、推奨 plugin metadata を確認 |
 | `runo context [DIR]` | Agent 向け project context の要約を表示 |
 | `runo context --json` | Agent 向け context を JSON で取得 |
-| `runo lint [PATH] [--scope ...] [--json]` | project state の health check |
+| `runo lint [PATH] [--scope ...] [--json]` | project state と推奨 plugin metadata の health check |
 | `runo migrate list/show/apply` | project-state migration を確認・適用 |
 | `runo config show` | 設定表示 |
 | `runo config add-simulator` | シミュレータ追加 |

--- a/docs/layers/knowledge.md
+++ b/docs/layers/knowledge.md
@@ -88,18 +88,61 @@ project/
 
 ### Codex plugin recommendation
 
-Adapter や site profile は、選択内容に応じて外部 Codex plugin を推薦できる。
+Adapter、simulator config、project config、site profile は、選択内容に応じて
+外部 Codex plugin を推薦できる。
 `runo init` / `runo setup` は推薦 plugin と導入手順を表示し、project harness
 (`AGENTS.md` / `CLAUDE.md`) にも同じ導線を残す。plugin の install / enable は
 ユーザーの Codex 環境に対する操作なので、runops project state には含めない。
+既存 project では `runo plugins` または `runo plugins --json` で、現在の
+project / simulator / site 設定から同じ推薦一覧を後から確認できる。Agent が最初に読む
+`runo context --json` と MCP `runops.project.inspect` にも同じ推薦を載せる。
+`runo context --json` は推薦一覧に加えて `delegated_capabilities`、`ok` /
+`strict_ok` / `summary` / `issues` / `collection_issues` も載せ、metadata warning /
+error があれば `codex_plugins` section を degraded にする。
+この context 内の `codex_plugins` は agent 向けの要約 shape なので、
+完全版 contract への参照として `inventory_schema` と `check_result_schema` を持つ。
+MCP `runops.project.plugins` は推薦一覧と同じメタデータ検査結果を返す。
+JSON payload には `schema_version` を含め、外部 agent / tool は field 追加に備えて
+未知 field を無視する。
+MCP capabilities の `codex_plugin_policy` は、`inventory_fields`、
+`check_result_fields`、`recommendation_fields`、`delegated_capabilities_field` により
+外部 client が使える field contract を広告する。
+`inventory_schema` と `check_result_schema` は JSON 出力 schema の場所を示し、
+JSON payload 自身の `$schema` にも同じ schema path を入れる。
+各推薦は互換用の `source` 文字列と、外部 tool が文字列を parse せずに使える
+`sources` 配列を返す。simulator key が adapter 名と異なる場合は、adapter 側の
+source と project 側の simulator source の両方を載せる。
+各推薦の `capabilities` は、runops 本体から外部 plugin へ委譲する役割ラベルであり、
+plugin の install 済み状態や実行許可を意味しない。
+`delegated_capabilities` は role label から推薦 plugin 名へ引くための index で、
+外部 agent / tool が `reason` 文字列を parse せずに委譲先を選ぶための補助である。
+同じ plugin 名が複数レイヤから推薦された場合、表示名、理由、導入手順などの実体
+metadata は最初の推薦を使い、`source` と `capabilities` は統合する。site や
+project は adapter package を変更せずに追加の委譲役割だけを載せられる。
+`runo plugins --check` は推薦名、理由、導入手順などのメタデータを検査する。
+`capabilities` は文字列または非空文字列の配列として読み、TOML table など
+machine-readable な role label にできない値は warning として返す。
+`simulators.toml` が外部 adapter を指しているが、その adapter が未導入で推薦を
+収集できない場合も warning として返す。
+`project.codex_plugins` / `simulators.<name>.codex_plugins` /
+`site.codex_plugins` の table 形が不正な場合も warning として返し、壊れた推薦を
+静かに無視しない。
+user-local な Codex plugin の install / enable 状態までは runops の管理対象にしない。
 
 例:
 
 - `emses`: `MPIEMSES3D Context`, `emout Context`
+- `beach`: `BEACH Context`
 - `camphor` site profile: `KUDPC HPC`
 
 private repo の plugin は GitHub 認証済み環境、local checkout marketplace、または
 利用者が自作する environment skill のいずれかで扱う。
+runops 開発ハーネス内の simulator skill / agent は、外部 plugin が利用できない時の
+最小 fallback と runops workflow の橋渡しに限定し、長文の simulator context を
+再び本体側へ戻さない。
+生成 project に materialize される adapter `agent_guide()` も同じく最小 fallback とし、
+完全な simulator manual や解析 cookbook ではなく plugin/knowledge source への導線に
+留める。
 
 ### refs/ — 任意のリファレンスミラー
 
@@ -253,6 +296,11 @@ surface_potential = { source = "work/volt", column = 1, description = "表面電
 
 simulator repo 側に `cookbook/` ディレクトリを置き、
 Agent がパラメータ生成の出発点として使える入力例・設定フラグメントを提供する。
+plugin-first な運用では、simulator 側 Codex plugin がこの cookbook を skill/context
+として提供する。runops 本体は cookbook 本文を内包せず、adapter / simulator config
+の `capabilities = ["cookbook"]` と plugin 推薦 metadata で導線だけを管理する。
+`refs/` は offline 利用、private repo、開発中 checkout を近くに置くための fallback
+mirror として扱う。
 
 - `cookbook/COOKBOOK.md` — この cookbook の概要と管理ガイド
 - `cookbook/index.toml` — 全 entry の目録

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,6 +47,26 @@ write / external / destructive tool は registry 上に disabled metadata とし
 将来 expose する場合も、`confirm=true`、`dry_run=false`、server policy enable、
 audit record を必須にする。
 
+Codex plugin については provider metadata と capabilities の
+`codex_plugin_policy` に境界を載せる。runops は plugin を自動 install / enable
+せず、project 側の推薦 metadata だけを検査する。install 済み状態はユーザー local な
+Codex 環境の責務として扱う。`inventory_schema_version` は
+`runops.project.plugins` / `runo plugins --json` が返す推薦 payload の schema を示す。
+`inventory_schema` と `check_result_schema` は、それぞれ
+`schemas/codex-plugin-inventory.json` と `schemas/codex-plugin-check-result.json`
+を指し、`runo plugins --json` / `runops.project.plugins` の JSON payload 自身も
+`$schema` に同じ値を含める。
+`inventory_fields`、`check_result_fields`、`recommendation_fields`、
+`source_fields`、`delegated_capabilities_field` は外部 client が期待できる field
+contract を示す。
+検査 payload は `ok`、warning を失敗扱いする `strict_ok`、`summary`、`issues` を
+返し、外部 tool は plugin 導入状態ではなく metadata 健全性だけを判断する。
+各推薦の `capabilities` は plugin へ委譲する役割ラベルで、install 状態ではない。
+各推薦は互換用の `source` 文字列に加えて、parse 済みの `sources` 配列を返す。
+`delegated_capabilities` は role label から推薦 plugin 名へ引くための index として
+返す。`capabilities` が文字列または非空文字列の配列として読めない場合は
+metadata warning になり、壊れた role index を静かに生成しない。
+
 ## Result Envelope
 
 すべての tool は `structuredContent` に Ops MCP envelope を返す。
@@ -99,7 +119,8 @@ error / blocked も JSON-RPC protocol error ではなく、通常の tool result
 | `runops.capabilities` | read | tool registry と safety metadata |
 | `runops.project.list` | read | server cwd から発見できる local project |
 | `runops.project.status` | read | compact project status |
-| `runops.project.inspect` | inspect | `runo context` 相当の詳細 context |
+| `runops.project.inspect` | inspect | `runo context` 相当の詳細 context。推奨 Codex plugins も含む |
+| `runops.project.plugins` | read | 推奨 Codex plugins と推薦メタデータ検査結果 |
 | `runops.project.doctor` | read | project diagnostics。環境保存などの mutation はしない |
 
 ### run / Slurm tools
@@ -193,6 +214,7 @@ enabled_tools = [
   "runops.project.list",
   "runops.project.status",
   "runops.project.inspect",
+  "runops.project.plugins",
   "runops.project.doctor",
   "runops.publication.exports.list",
   "runops.publication.export.inspect",

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -7,7 +7,7 @@ project state の整合性を確認します。
 ```bash
 runo lint
 runo lint --json
-runo lint --scope structure,analysis,knowledge
+runo lint --scope structure,analysis,knowledge,plugins
 runo lint --strict
 ```
 
@@ -15,9 +15,9 @@ runo lint --strict
 
 | Command | 役割 |
 |---------|------|
-| `runo doctor` | Python 環境、Slurm、site preset、`.runops/environment.toml` など実行環境を確認する |
-| `runo context --json` | Agent が最初に読む project context を要約する |
-| `runo lint` | project state が再開・解析・handoff 可能かを検査する |
+| `runo doctor` | Python 環境、Slurm、site preset、`.runops/environment.toml`、推奨 Codex plugin metadata などを確認する |
+| `runo context --json` | Agent が最初に読む project context、推奨 Codex plugins、読む入口を要約する |
+| `runo lint` | project state と推奨 plugin metadata が再開・解析・handoff 可能かを検査する |
 | `runo migrate apply <id>` | migration guide に登録された定型修復を適用する |
 
 `runo lint` は layer そのものではなく、Experiment / Execution / Analysis /
@@ -34,12 +34,13 @@ Research / Knowledge / Harness / Upstream の各 layer を横断して見る hea
 | `provenance` | completed run の `git_commit`, executable hash, simulator version |
 | `analysis` | completed run の `analysis/summary.json`, artifact index, legacy `figures_index.json` |
 | `knowledge` | `research/agenda.md` の template 状態、Next Actions の evidence path、`.runops/facts.toml` の source |
+| `plugins` | project / simulator / site 由来の推奨 Codex plugin metadata と委譲 role index。install 済み状態は見ない |
 
 `--scope` は comma-separated です。
 
 ```bash
 runo lint --scope structure
-runo lint --scope analysis,knowledge
+runo lint --scope analysis,knowledge,plugins
 ```
 
 ## Exit Code
@@ -70,6 +71,6 @@ CLI で修復できない finding は、手作業で直すか、汎用化でき�
 Agent が project に入ったときの標準動線:
 
 1. `runo context --json` で現在地を把握する。
-2. 必要なら `runo lint --scope structure,analysis,knowledge` で読む入口と成果物索引を確認する。
+2. 必要なら `runo lint --scope structure,analysis,knowledge,plugins` で読む入口、成果物索引、推奨 plugin metadata を確認する。
 3. migration finding があれば `runo migrate apply <id> --dry-run` で確認する。
 4. 直したこと、skip したこと、保留したことを `notes/YYYY-MM-DD.md` に残す。

--- a/docs/toml-reference.md
+++ b/docs/toml-reference.md
@@ -13,6 +13,13 @@ Project-level configuration. One per project root.
 name = "emses-sheath"           # Required. Project name
 description = "EMSES sheath simulations"  # Optional.
 version = "1.0"                 # Optional.
+
+[project.codex_plugins.analysis-context]
+display_name = "Analysis Context"
+visibility = "private-or-gated"
+reason = "Project-specific analysis and handoff workflow guidance."
+capabilities = ["analysis-workflow", "handoff"]
+install_hint = "codex plugin add analysis-context@project"
 ```
 
 | Field | Type | Required | Description |
@@ -20,6 +27,29 @@ version = "1.0"                 # Optional.
 | `project.name` | string | Yes | Project identifier |
 | `project.description` | string | No | Human-readable description |
 | `project.version` | string | No | Project version |
+| `project.codex_plugins` | table | No | Project-wide Codex plugin recommendations not tied to one simulator or site. |
+
+### `[project.codex_plugins.<plugin>]`
+
+project 全体に紐づく外部 Codex plugin 推薦。解析 workflow、チーム内
+handoff、project 固有の reference plugin など、simulator / site どちらにも
+属さない導線を置く。runops は plugin を自動 install / enable しない。
+`runo plugins`、`runo setup` の出力、`runo update-harness` で再生成される
+`AGENTS.md` / `CLAUDE.md` はこの project-wide 推薦を同じ inventory として扱う。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `display_name` | string | 表示名 |
+| `visibility` | string | `"public"` または `"private-or-gated"` |
+| `reason` | string | 推奨理由 |
+| `capabilities` | string[] / string | plugin に委譲する役割ラベル。配列を推奨し、単一 role は文字列でも可。例: `"input-review"`, `"run-diagnose"` |
+| `install_hint` | string | 導入コマンドまたは手順 |
+| `activation_hint` | string | install 後の有効化・再起動手順 |
+
+同じ plugin 名が adapter、simulator、project、site の複数スコープから推薦された場合、
+表示名、理由、導入手順、visibility は最初の推薦を使い、`source` と
+`capabilities` は統合される。project / site 側は adapter を編集せずに追加の委譲
+役割だけを載せられる。
 
 ### `[knowledge]` section (optional)
 
@@ -108,6 +138,23 @@ executable = "beach"
 | `source_repo` | string | No | Source repository path (`local_source` mode only) |
 | `build_command` | string | No | Build command (`local_source` mode only) |
 | `modules` | string[] | No | Simulator-specific HPC modules (e.g. hdf5, fftw). Site-common modules (intel, intelmpi) are defined in `launchers.toml`. Both are merged in job.sh. |
+| `codex_plugins` | table | No | Project-side Codex plugin recommendations for this simulator. Used when workflow guidance lives outside runops / adapter packages. |
+
+### `[simulators.<name>.codex_plugins.<plugin>]`
+
+simulator 設定に紐づく外部 Codex plugin 推薦。Adapter の `codex_plugins()` を
+変更できない project 固有 workflow や、外部 adapter package が未導入の時にも、
+推薦 metadata を project 側で明示できる。runops は plugin を自動 install / enable
+しない。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `display_name` | string | 表示名 |
+| `visibility` | string | `"public"` または `"private-or-gated"` |
+| `reason` | string | 推奨理由 |
+| `capabilities` | string[] / string | plugin に委譲する役割ラベル。配列を推奨し、単一 role は文字列でも可。例: `"parameter-design"`, `"output-analysis"`, `"cookbook"` |
+| `install_hint` | string | 導入コマンドまたは手順 |
+| `activation_hint` | string | install 後の有効化・再起動手順 |
 
 ### resolver_mode
 
@@ -255,6 +302,7 @@ activation_hint = "Start a new Codex thread after installing."
 | `display_name` | string | 表示名 |
 | `visibility` | string | `"public"` または `"private-or-gated"` |
 | `reason` | string | 推奨理由 |
+| `capabilities` | string[] / string | plugin に委譲する役割ラベル。配列を推奨し、単一 role は文字列でも可。例: `"host-role-routing"`, `"slurm-jobs"` |
 | `install_hint` | string | 導入コマンドまたは手順 |
 | `activation_hint` | string | install 後の有効化・再起動手順 |
 
@@ -1028,7 +1076,15 @@ All TOML files support schema validation via `#:schema` comments:
 ...
 ```
 
-Schema files: `schemas/runops.json`, `schemas/simulators.json`, `schemas/launchers.json`, `schemas/case.json`, `schemas/survey.json`, `schemas/manifest.json`, `schemas/campaign.json`
+Schema files: `schemas/runops.json`, `schemas/simulators.json`,
+`schemas/launchers.json`, `schemas/site.json`, `schemas/case.json`,
+`schemas/survey.json`, `schemas/manifest.json`, `schemas/campaign.json`.
+Codex plugin 推薦 metadata は共通 sub-schema
+`schemas/codex-plugin-recommendation.json` を参照する。
+`runo plugins --json` / MCP `runops.project.plugins` の JSON 出力 contract は
+`schemas/codex-plugin-inventory.json` と
+`schemas/codex-plugin-check-result.json` に定義する。JSON payload は `$schema`
+field に対応する schema path を含む。
 
 ---
 

--- a/schemas/codex-plugin-check-result.json
+++ b/schemas/codex-plugin-check-result.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Codex plugin check result",
+  "description": "Metadata validation result emitted by runo plugins --check and runops.project.plugins",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "ok",
+    "strict_ok",
+    "summary",
+    "inventory",
+    "issues"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "schemas/codex-plugin-check-result.json"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "strict_ok": {
+      "type": "boolean"
+    },
+    "summary": {
+      "type": "object",
+      "required": ["recommendations", "errors", "warnings"],
+      "properties": {
+        "recommendations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "errors": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warnings": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "inventory": {
+      "$ref": "codex-plugin-inventory.json"
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "$ref": "codex-plugin-inventory.json#/definitions/issue"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/codex-plugin-inventory.json
+++ b/schemas/codex-plugin-inventory.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Codex plugin inventory",
+  "description": "Machine-readable advisory Codex plugin inventory emitted by runops",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "project",
+    "simulators",
+    "site",
+    "management",
+    "recommendations",
+    "delegated_capabilities",
+    "collection_issues"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "schemas/codex-plugin-inventory.json"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "project": {
+      "type": "object",
+      "required": ["name", "root"],
+      "properties": {
+        "name": { "type": "string" },
+        "root": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "simulators": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "site": {
+      "type": "string"
+    },
+    "management": {
+      "type": "object",
+      "required": [
+        "runops_installs_plugins",
+        "runops_enables_plugins",
+        "runops_inspects_user_install_state",
+        "activation_scope"
+      ],
+      "properties": {
+        "runops_installs_plugins": { "type": "boolean" },
+        "runops_enables_plugins": { "type": "boolean" },
+        "runops_inspects_user_install_state": { "type": "boolean" },
+        "activation_scope": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "recommendations": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/recommendation" }
+    },
+    "delegated_capabilities": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "collection_issues": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/issue" }
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "recommendation": {
+      "type": "object",
+      "required": [
+        "name",
+        "display_name",
+        "reason",
+        "install_hint",
+        "activation_hint",
+        "visibility",
+        "source",
+        "sources",
+        "capabilities"
+      ],
+      "properties": {
+        "name": { "type": "string" },
+        "display_name": { "type": "string" },
+        "reason": { "type": "string" },
+        "install_hint": { "type": "string" },
+        "activation_hint": { "type": "string" },
+        "visibility": { "type": "string" },
+        "source": { "type": "string" },
+        "sources": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "issue": {
+      "type": "object",
+      "required": ["severity", "plugin_name", "field", "message", "source"],
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning"]
+        },
+        "plugin_name": { "type": "string" },
+        "field": { "type": "string" },
+        "message": { "type": "string" },
+        "source": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/codex-plugin-recommendation.json
+++ b/schemas/codex-plugin-recommendation.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Codex plugin recommendation",
+  "description": "Advisory external Codex plugin recommendation metadata",
+  "type": "object",
+  "required": ["display_name", "reason", "install_hint"],
+  "properties": {
+    "display_name": {
+      "type": "string",
+      "description": "Human-readable plugin name"
+    },
+    "visibility": {
+      "type": "string",
+      "enum": ["public", "private-or-gated"],
+      "description": "Plugin visibility"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Why this plugin is recommended"
+    },
+    "capabilities": {
+      "description": "Delegated role labels handled by this plugin",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "install_hint": {
+      "type": "string",
+      "description": "Manual installation command or procedure"
+    },
+    "activation_hint": {
+      "type": "string",
+      "description": "How to activate the plugin after installation"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/runops.json
+++ b/schemas/runops.json
@@ -16,6 +16,13 @@
         "description": {
           "type": "string",
           "description": "Project description"
+        },
+        "codex_plugins": {
+          "type": "object",
+          "description": "Project-wide external Codex plugin recommendations",
+          "additionalProperties": {
+            "$ref": "codex-plugin-recommendation.json"
+          }
         }
       }
     },

--- a/schemas/simulators.json
+++ b/schemas/simulators.json
@@ -36,6 +36,13 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "HPC module names to load"
+          },
+          "codex_plugins": {
+            "type": "object",
+            "description": "Simulator-scoped external Codex plugin recommendations",
+            "additionalProperties": {
+              "$ref": "codex-plugin-recommendation.json"
+            }
           }
         }
       }

--- a/schemas/site.json
+++ b/schemas/site.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "site.toml",
+  "description": "HPC site profile and external Codex plugin recommendations",
+  "type": "object",
+  "required": ["site"],
+  "properties": {
+    "site": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Site identifier"
+        },
+        "resource_style": {
+          "type": "string",
+          "enum": ["standard", "rsc"],
+          "description": "SBATCH resource directive style"
+        },
+        "modules": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Site-wide HPC modules"
+        },
+        "stdout": {
+          "type": "string",
+          "description": "SBATCH stdout path format"
+        },
+        "stderr": {
+          "type": "string",
+          "description": "SBATCH stderr path format"
+        },
+        "extra_sbatch": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional raw SBATCH directives"
+        },
+        "setup_commands": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Shell commands run before the simulator command"
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables exported in job scripts"
+        },
+        "simulators": {
+          "type": "object",
+          "description": "Per-simulator site settings",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "modules": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Additional modules for this simulator"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "codex_plugins": {
+          "type": "object",
+          "description": "Site-scoped external Codex plugin recommendations",
+          "additionalProperties": {
+            "$ref": "codex-plugin-recommendation.json"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "launcher": {
+      "type": "object",
+      "description": "Bundled site launcher defaults used by runo init",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/runops/adapters/base.py
+++ b/src/runops/adapters/base.py
@@ -214,17 +214,19 @@ class SimulatorAdapter(ABC):
 
     @classmethod
     def agent_guide(cls) -> str:
-        """Return AI agent guide for this simulator as markdown.
+        """Return a minimal AI agent fallback guide as markdown.
 
-        Override in subclasses to provide simulator-specific knowledge
-        including input/output formats, key parameters, typical
-        workflows, and documentation references.
+        Override in subclasses to point agents at recommended plugins,
+        explicit knowledge sources, and the runops-side adapter boundary.
+        Long-form simulator knowledge, analysis workflows, and environment
+        procedures belong in external plugins or project-local knowledge
+        sources, not in package-bundled adapter guides.
 
         Returns:
-            Markdown string for inclusion in CLAUDE.md / AGENTS.md.
+            Markdown string for inclusion in generated agent harness files.
         """
         name = getattr(cls, "adapter_name", cls.__name__)
-        return f"### {name}\n\nNo detailed guide available.\n"
+        return f"### {name}\n\nNo package-bundled fallback guide available.\n"
 
     @property
     @abstractmethod

--- a/src/runops/adapters/contrib/beach/adapter.py
+++ b/src/runops/adapters/contrib/beach/adapter.py
@@ -40,6 +40,7 @@ from runops.adapters.contrib.beach.validation import (
 from runops.adapters.contrib.beach.validation import (
     validate_params as validate_beach_params,
 )
+from runops.core.codex_plugin import CodexPluginRecommendation
 from runops.core.validation import ValidationIssue
 
 logger = logging.getLogger(__name__)
@@ -162,6 +163,43 @@ class BeachAdapter(SimulatorAdapter):
                 "cookbook/**/*.md",
             ],
         }
+
+    @classmethod
+    def codex_plugins(cls) -> list[CodexPluginRecommendation]:
+        """Return Codex plugins recommended for BEACH projects."""
+        return [
+            CodexPluginRecommendation(
+                name="beach-context",
+                display_name="BEACH Context",
+                reason=(
+                    "BEACH configuration review, run diagnosis, case design, "
+                    "output analysis, simulator learning, method summaries, "
+                    "and issue report drafting."
+                ),
+                install_hint=(
+                    "codex plugin marketplace add Nkzono99/BEACH "
+                    "--ref main "
+                    "--sparse .agents/plugins "
+                    "--sparse plugins/beach-context"
+                ),
+                activation_hint=(
+                    "Open Codex /plugins, install `BEACH Context`, then "
+                    "restart Codex or start a new Codex thread."
+                ),
+                visibility="public",
+                source="simulator:beach",
+                capabilities=(
+                    "config-review",
+                    "case-design",
+                    "run-diagnose",
+                    "output-analysis",
+                    "method-summary",
+                    "simulator-guide",
+                    "cookbook",
+                    "issue-report",
+                ),
+            )
+        ]
 
     @classmethod
     def parameter_schema(cls) -> dict[str, dict[str, Any]]:

--- a/src/runops/adapters/contrib/emses/adapter.py
+++ b/src/runops/adapters/contrib/emses/adapter.py
@@ -187,6 +187,16 @@ class EmseAdapter(SimulatorAdapter):
                 ),
                 visibility="private-or-gated",
                 source="simulator:emses",
+                capabilities=(
+                    "input-review",
+                    "parameter-design",
+                    "run-diagnose",
+                    "output-analysis",
+                    "method-summary",
+                    "simulator-guide",
+                    "cookbook",
+                    "issue-report",
+                ),
             ),
             CodexPluginRecommendation(
                 name="emout-context",
@@ -208,6 +218,15 @@ class EmseAdapter(SimulatorAdapter):
                 ),
                 visibility="public",
                 source="simulator:emses",
+                capabilities=(
+                    "output-analysis",
+                    "visualization-script",
+                    "visualization-workflow",
+                    "script-review",
+                    "output-diagnose",
+                    "issue-report",
+                    "feedback-report",
+                ),
             ),
         ]
 

--- a/src/runops/cli/init/command.py
+++ b/src/runops/cli/init/command.py
@@ -30,6 +30,7 @@ from runops.cli.init.serialization import (
 )
 from runops.core.discovery import validate_uniqueness
 from runops.core.exceptions import DuplicateRunIdError, ProjectConfigError
+from runops.core.plugins import check_project_codex_plugins
 from runops.core.project import load_project
 from runops.harness._plugins import (
     collect_plugin_recommendations,
@@ -223,6 +224,7 @@ def init(
     )
     codex_plugin_recommendations = collect_plugin_recommendations(
         sim_names,
+        simulator_configs=sim_configs or None,
         extra_plugins=site_profile.codex_plugins if site_profile else None,
     )
 
@@ -276,6 +278,7 @@ def init(
                 site_only["site"] = bundled_data["site"]
             if site_only and tomli_w is not None:
                 with open(site_file, "wb") as f:
+                    f.write(f"#:schema {_SCHEMA_BASE_URL}/site.json\n".encode())
                     tomli_w.dump(site_only, f)
                 created.append("site.toml")
             elif site_only:
@@ -667,6 +670,37 @@ def doctor(
             failures.append("campaign.toml")
     else:
         typer.echo("[INFO] No campaign.toml (optional)")
+
+    # Codex plugin recommendation metadata. This does not inspect user-local
+    # plugin installation state; it only validates project-side recommendations.
+    try:
+        plugin_check = check_project_codex_plugins(project_dir)
+        errors = [issue for issue in plugin_check.issues if issue.severity == "error"]
+        warnings = [
+            issue for issue in plugin_check.issues if issue.severity == "warning"
+        ]
+        if errors:
+            typer.echo(
+                "[FAIL] Codex plugin recommendation metadata: "
+                f"{len(errors)} error(s), {len(warnings)} warning(s)"
+            )
+            failures.append("codex_plugins")
+        elif warnings:
+            typer.echo(
+                "[WARN] Codex plugin recommendation metadata: "
+                f"0 error(s), {len(warnings)} warning(s)"
+            )
+        else:
+            typer.echo("[PASS] Codex plugin recommendation metadata OK")
+        for issue in plugin_check.issues:
+            source = f" source={issue.source}" if issue.source else ""
+            typer.echo(
+                f"       [{issue.severity}] {issue.plugin_name}.{issue.field}:"
+                f"{source} {issue.message}"
+            )
+    except Exception as e:
+        typer.echo(f"[FAIL] Codex plugin recommendation metadata: {e}")
+        failures.append("codex_plugins")
 
     # Final verdict
     if failures:

--- a/src/runops/cli/main.py
+++ b/src/runops/cli/main.py
@@ -32,6 +32,7 @@ from runops.cli.notes import append as notes_append
 from runops.cli.notes import archive as notes_archive
 from runops.cli.notes import list_notes as notes_list
 from runops.cli.notes import show as notes_show
+from runops.cli.plugins import plugins
 from runops.cli.regenerate import regenerate
 from runops.cli.retry import retry
 from runops.cli.setup import setup
@@ -174,6 +175,7 @@ def _build_app(name: str) -> typer.Typer:
     cli_app.add_typer(knowledge_app, name="knowledge")
     cli_app.add_typer(mcp_app, name="mcp")
     cli_app.command("context")(context)
+    cli_app.command("plugins")(plugins)
     cli_app.command("lint")(lint)
     cli_app.add_typer(case_app, name="case")
     cli_app.add_typer(runs_app, name="runs")

--- a/src/runops/cli/plugins.py
+++ b/src/runops/cli/plugins.py
@@ -1,0 +1,151 @@
+"""CLI command for external Codex plugin recommendations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from runops.core.exceptions import SimctlError
+from runops.core.plugins import (
+    CodexPluginCheckResult,
+    CodexPluginInventory,
+    CodexPluginIssue,
+)
+
+
+def plugins(
+    directory: Annotated[
+        Path,
+        typer.Argument(
+            help="Project directory or a path inside one (default: cwd).",
+            exists=True,
+        ),
+    ] = Path("."),
+    output_json: Annotated[
+        bool,
+        typer.Option("--json/--no-json", help="Emit JSON output."),
+    ] = False,
+    check: Annotated[
+        bool,
+        typer.Option(
+            "--check",
+            help=(
+                "Validate recommendation metadata. Does not inspect or mutate "
+                "user-local Codex plugin installation state."
+            ),
+        ),
+    ] = False,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help="With --check, fail on warnings as well as errors.",
+        ),
+    ] = False,
+) -> None:
+    """List or check external Codex plugins recommended for the project."""
+    from runops.core.plugins import (
+        check_project_codex_plugins,
+        load_project_codex_plugin_inventory,
+    )
+
+    try:
+        if check:
+            result = check_project_codex_plugins(directory)
+            inventory = result.inventory
+        else:
+            result = None
+            inventory = load_project_codex_plugin_inventory(directory)
+    except SimctlError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+    except (OSError, ValueError) as exc:
+        typer.echo(f"Error loading plugin recommendations: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if output_json:
+        payload = result.to_dict() if result is not None else inventory.to_dict()
+        typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        if result is not None and not _check_passed(result, strict=strict):
+            raise typer.Exit(code=1)
+        return
+
+    _echo_plugin_inventory(inventory)
+    if result is not None:
+        _echo_plugin_check_result(result)
+        if not _check_passed(result, strict=strict):
+            raise typer.Exit(code=1)
+
+
+def _echo_plugin_inventory(inventory: CodexPluginInventory) -> None:
+    """Print a human-readable plugin recommendation summary."""
+    typer.echo(
+        f"Codex plugin recommendations for {inventory.project_name} "
+        f"({inventory.project_dir})"
+    )
+    typer.echo(
+        "runops does not install or enable these plugins; manage them in your "
+        "user-local Codex environment."
+    )
+    if inventory.simulator_names:
+        typer.echo(f"Simulators: {', '.join(inventory.simulator_names)}")
+    typer.echo(f"Site: {inventory.site_name}")
+    delegated_capabilities = inventory.delegated_capabilities()
+    if delegated_capabilities:
+        typer.echo("Delegated capabilities:")
+        for capability, plugin_names in delegated_capabilities.items():
+            typer.echo(f"  - {capability}: {', '.join(plugin_names)}")
+
+    if not inventory.recommendations:
+        typer.echo("\nNo recommended Codex plugins.")
+        return
+
+    typer.echo("\nRecommended Codex plugins:")
+    for plugin in inventory.recommendations:
+        visibility = f" [{plugin.visibility}]" if plugin.visibility != "public" else ""
+        typer.echo(f"  - {plugin.display_name} (`{plugin.name}`){visibility}")
+        if plugin.source:
+            typer.echo(f"    Source: {plugin.source}")
+        if plugin.capabilities:
+            typer.echo(f"    Capabilities: {', '.join(plugin.capabilities)}")
+        if plugin.reason:
+            typer.echo(f"    Why: {plugin.reason}")
+        if plugin.install_hint:
+            typer.echo("    Install:")
+            for line in plugin.install_hint.strip().splitlines():
+                typer.echo(f"      {line}")
+        if plugin.activation_hint:
+            typer.echo(f"    Activate: {plugin.activation_hint}")
+
+
+def _check_passed(result: CodexPluginCheckResult, *, strict: bool) -> bool:
+    """Return whether a check result should pass for the requested strictness."""
+    return result.ok_with_strict() if strict else result.ok
+
+
+def _echo_plugin_check_result(result: CodexPluginCheckResult) -> None:
+    """Print a human-readable plugin metadata check result."""
+    if not result.issues:
+        typer.echo("\nPlugin recommendation metadata: OK")
+        return
+
+    errors = [issue for issue in result.issues if issue.severity == "error"]
+    warnings = [issue for issue in result.issues if issue.severity == "warning"]
+    typer.echo(
+        "\nPlugin recommendation metadata: "
+        f"{len(errors)} error(s), {len(warnings)} warning(s)"
+    )
+    for issue in result.issues:
+        _echo_plugin_issue(issue)
+
+
+def _echo_plugin_issue(issue: CodexPluginIssue) -> None:
+    """Print one plugin metadata issue."""
+    source = f" source={issue.source}" if issue.source else ""
+    typer.echo(
+        f"  - [{issue.severity}] {issue.plugin_name}.{issue.field}:{source} "
+        f"{issue.message}"
+    )

--- a/src/runops/cli/setup.py
+++ b/src/runops/cli/setup.py
@@ -12,6 +12,7 @@ import typer
 from runops import __version__
 from runops.cli.init.github_auth import ensure_github_auth_for_simulators
 from runops.core.exceptions import ProjectConfigError
+from runops.core.plugins import build_project_codex_plugin_inventory
 from runops.core.project import ProjectConfig, load_project
 from runops.core.repository import repo_name_from_url
 from runops.harness._plugins import (
@@ -158,11 +159,16 @@ def setup(
         skip=skip_github_auth_check,
         include_refs=with_refs,
     )
-    site_profile = load_site_profile_for_recommendations(project_dir)
-    codex_plugin_recommendations = collect_plugin_recommendations(
-        sim_names,
-        site_profile=site_profile,
-    )
+    if project is not None:
+        codex_plugin_recommendations = list(
+            build_project_codex_plugin_inventory(project).recommendations
+        )
+    else:
+        site_profile = load_site_profile_for_recommendations(project_dir)
+        codex_plugin_recommendations = collect_plugin_recommendations(
+            sim_names,
+            site_profile=site_profile,
+        )
 
     created: list[str] = []
     skipped: list[str] = []

--- a/src/runops/cli/update_harness.py
+++ b/src/runops/cli/update_harness.py
@@ -34,6 +34,7 @@ from runops.cli.init.scaffold import (
     _create_research_skeleton,
 )
 from runops.core.exceptions import SimctlError
+from runops.core.plugins import build_project_codex_plugin_inventory
 from runops.core.project import find_project_root, load_project
 from runops.core.upgrade_chain import (
     UpgradePlan,
@@ -42,10 +43,6 @@ from runops.core.upgrade_chain import (
     latest_version_in_versions,
 )
 from runops.harness._adapters import collect_doc_repos
-from runops.harness._plugins import (
-    collect_plugin_recommendations,
-    load_site_profile_for_recommendations,
-)
 from runops.harness.builder import (
     GITIGNORE_PATH,
     applied_harness_runops_version,
@@ -516,7 +513,9 @@ def update_harness(
     project = load_project(project_dir)
     project_name = project.name
     simulator_names = list(project.simulators.keys())
-    site_profile = load_site_profile_for_recommendations(project_dir)
+    codex_plugin_recommendations = list(
+        build_project_codex_plugin_inventory(project).recommendations
+    )
 
     # Read [harness] settings
     upstream_feedback = read_upstream_feedback_setting(project_dir)
@@ -539,10 +538,7 @@ def update_harness(
         upstream_feedback=upstream_feedback,
         knowledge_imports_path=knowledge_imports_path,
         include_reference_repos=_has_reference_repos(project_dir, simulator_names),
-        codex_plugin_recommendations=collect_plugin_recommendations(
-            simulator_names,
-            site_profile=site_profile,
-        ),
+        codex_plugin_recommendations=codex_plugin_recommendations,
     )
 
     # Filter by --only

--- a/src/runops/core/codex_plugin.py
+++ b/src/runops/core/codex_plugin.py
@@ -5,6 +5,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+CODEX_PLUGIN_ACTIVATION_SCOPE = "user-local Codex environment"
+CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION = 1
+CODEX_PLUGIN_INVENTORY_SCHEMA_PATH = "schemas/codex-plugin-inventory.json"
+CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH = "schemas/codex-plugin-check-result.json"
+DEFAULT_CODEX_PLUGIN_ACTIVATION_HINT = (
+    "Install from /plugins or restart Codex after CLI installation."
+)
+
+
+def codex_plugin_management_policy() -> dict[str, bool | str]:
+    """Return runops' management boundary for external Codex plugins."""
+    return {
+        "runops_installs_plugins": False,
+        "runops_enables_plugins": False,
+        "runops_inspects_user_install_state": False,
+        "activation_scope": CODEX_PLUGIN_ACTIVATION_SCOPE,
+    }
+
 
 @dataclass(frozen=True)
 class CodexPluginRecommendation:
@@ -19,11 +37,71 @@ class CodexPluginRecommendation:
     display_name: str
     reason: str
     install_hint: str
-    activation_hint: str = (
-        "Install from /plugins or restart Codex after CLI installation."
-    )
+    activation_hint: str = DEFAULT_CODEX_PLUGIN_ACTIVATION_HINT
     visibility: str = "public"
     source: str = ""
+    capabilities: tuple[str, ...] = ()
+
+    def source_labels(self) -> tuple[str, ...]:
+        """Return normalized source labels for this recommendation."""
+        return _source_parts(self.source)
+
+    def with_additional_source(self, source: str) -> CodexPluginRecommendation:
+        """Return a copy with additional source labels merged in."""
+        sources = _unique_non_empty_strings(
+            (*self.source_labels(), *_source_parts(source))
+        )
+        return CodexPluginRecommendation(
+            name=self.name,
+            display_name=self.display_name,
+            reason=self.reason,
+            install_hint=self.install_hint,
+            activation_hint=self.activation_hint,
+            visibility=self.visibility,
+            source=", ".join(sources),
+            capabilities=self.capabilities,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable recommendation payload."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "reason": self.reason,
+            "install_hint": self.install_hint,
+            "activation_hint": self.activation_hint,
+            "visibility": self.visibility,
+            "source": self.source,
+            "sources": list(self.source_labels()),
+            "capabilities": list(self.capabilities),
+        }
+
+    def to_site_mapping(self) -> dict[str, Any]:
+        """Return TOML metadata suitable for ``[site.codex_plugins.<name>]``."""
+        mapping: dict[str, Any] = {
+            "display_name": self.display_name,
+            "visibility": self.visibility,
+            "reason": self.reason,
+            "install_hint": self.install_hint,
+            "activation_hint": self.activation_hint,
+        }
+        if self.capabilities:
+            mapping["capabilities"] = list(self.capabilities)
+        return mapping
+
+
+def _capabilities_from_value(value: Any) -> tuple[str, ...]:
+    """Return advisory capability labels from TOML metadata."""
+    if value in (None, ""):
+        return ()
+    if isinstance(value, str):
+        capability = value.strip()
+        return (capability,) if capability else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            item.strip() for item in value if isinstance(item, str) and item.strip()
+        )
+    return ()
 
 
 def codex_plugin_from_mapping(
@@ -39,9 +117,10 @@ def codex_plugin_from_mapping(
     activation_hint = str(
         data.get("activation_hint")
         or data.get("activation")
-        or "Install from /plugins or restart Codex after CLI installation."
+        or DEFAULT_CODEX_PLUGIN_ACTIVATION_HINT
     )
     visibility = str(data.get("visibility") or "public")
+    capabilities = _capabilities_from_value(data.get("capabilities"))
     return CodexPluginRecommendation(
         name=name,
         display_name=display_name,
@@ -50,18 +129,75 @@ def codex_plugin_from_mapping(
         activation_hint=activation_hint,
         visibility=visibility,
         source=source,
+        capabilities=capabilities,
     )
+
+
+def _unique_non_empty_strings(values: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    """Return non-empty strings without duplicates while preserving order."""
+    seen: set[str] = set()
+    unique: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(normalized)
+    return tuple(unique)
+
+
+def _source_parts(source: str) -> tuple[str, ...]:
+    """Return normalized comma-separated source labels."""
+    return _unique_non_empty_strings(tuple(source.split(",")))
+
+
+def _merge_codex_plugin_pair(
+    first: CodexPluginRecommendation,
+    later: CodexPluginRecommendation,
+) -> CodexPluginRecommendation:
+    """Merge additive metadata while preserving the first recommendation."""
+    sources = _unique_non_empty_strings(
+        (*_source_parts(first.source), *_source_parts(later.source))
+    )
+    capabilities = _unique_non_empty_strings((*first.capabilities, *later.capabilities))
+    return CodexPluginRecommendation(
+        name=first.name,
+        display_name=first.display_name,
+        reason=first.reason,
+        install_hint=first.install_hint,
+        activation_hint=first.activation_hint,
+        visibility=first.visibility,
+        source=", ".join(sources),
+        capabilities=capabilities,
+    )
+
+
+def merge_codex_plugins(
+    recommendations: list[CodexPluginRecommendation],
+) -> list[CodexPluginRecommendation]:
+    """Return recommendations merged by plugin name.
+
+    Scalar metadata from the first recommendation wins.  Additive metadata
+    such as ``source`` and ``capabilities`` is merged so project, simulator, and
+    site layers can extend delegated roles without editing the original adapter.
+    """
+    indexes: dict[str, int] = {}
+    merged: list[CodexPluginRecommendation] = []
+    for recommendation in recommendations:
+        existing_index = indexes.get(recommendation.name)
+        if existing_index is None:
+            indexes[recommendation.name] = len(merged)
+            merged.append(recommendation)
+            continue
+        merged[existing_index] = _merge_codex_plugin_pair(
+            merged[existing_index],
+            recommendation,
+        )
+    return merged
 
 
 def unique_codex_plugins(
     recommendations: list[CodexPluginRecommendation],
 ) -> list[CodexPluginRecommendation]:
     """Return recommendations de-duplicated by plugin name."""
-    seen: set[str] = set()
-    unique: list[CodexPluginRecommendation] = []
-    for recommendation in recommendations:
-        if recommendation.name in seen:
-            continue
-        seen.add(recommendation.name)
-        unique.append(recommendation)
-    return unique
+    return merge_codex_plugins(recommendations)

--- a/src/runops/core/context.py
+++ b/src/runops/core/context.py
@@ -14,6 +14,12 @@ from pathlib import Path
 from typing import Any
 
 import runops
+from runops.core.codex_plugin import (
+    CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_PATH,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+    codex_plugin_management_policy,
+)
 from runops.core.exceptions import SimctlError
 
 logger = logging.getLogger(__name__)
@@ -88,6 +94,11 @@ def build_project_context(project_root: Path) -> dict[str, Any]:
         project_root, diagnostics, section_status
     )
 
+    # -- External Codex plugins --
+    ctx["codex_plugins"] = _collect_codex_plugins(
+        project_root, diagnostics, section_status
+    )
+
     # -- Available actions --
     try:
         from runops.core.actions import list_actions
@@ -117,6 +128,7 @@ def build_project_context(project_root: Path) -> dict[str, Any]:
             "recent_failures",
             "facts",
             "knowledge",
+            "codex_plugins",
             "available_actions",
         )
     }
@@ -548,3 +560,79 @@ def _collect_knowledge_paths(
         logger.debug("Failed to collect knowledge integration details", exc_info=True)
 
     return result
+
+
+def _collect_codex_plugins(
+    root: Path,
+    diagnostics: list[dict[str, str]],
+    section_status: dict[str, str],
+) -> dict[str, Any]:
+    """Collect advisory Codex plugin recommendations for the project."""
+    try:
+        from runops.core.plugins import (
+            build_project_codex_plugin_inventory,
+            check_codex_plugin_inventory,
+        )
+        from runops.core.project import load_project
+
+        inventory = build_project_codex_plugin_inventory(load_project(root))
+        check_result = check_codex_plugin_inventory(inventory)
+        payload = check_result.to_dict()
+        issue_level = "error" if not check_result.ok else "warning"
+        if check_result.issues:
+            _record_diagnostic(
+                diagnostics,
+                section_status,
+                section="codex_plugins",
+                level=issue_level,
+                message=(
+                    "Codex plugin metadata has "
+                    f"{payload['summary']['errors']} error(s) and "
+                    f"{payload['summary']['warnings']} warning(s); "
+                    "inspect runo plugins --check."
+                ),
+            )
+        inventory_payload = payload["inventory"]
+        return {
+            "schema_version": payload["schema_version"],
+            "inventory_schema": inventory_payload["$schema"],
+            "check_result_schema": payload["$schema"],
+            "ok": payload["ok"],
+            "strict_ok": payload["strict_ok"],
+            "summary": payload["summary"],
+            "simulators": inventory_payload["simulators"],
+            "site": inventory_payload["site"],
+            "management": inventory_payload["management"],
+            "recommendations": inventory_payload["recommendations"],
+            "delegated_capabilities": inventory_payload["delegated_capabilities"],
+            "collection_issues": inventory_payload["collection_issues"],
+            "issues": payload["issues"],
+        }
+    except Exception as exc:
+        _record_diagnostic(
+            diagnostics,
+            section_status,
+            section="codex_plugins",
+            message=f"Failed to collect Codex plugin recommendations: {exc}",
+            level="warning",
+        )
+        logger.debug("Failed to collect Codex plugin recommendations", exc_info=True)
+        return {
+            "schema_version": CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+            "inventory_schema": CODEX_PLUGIN_INVENTORY_SCHEMA_PATH,
+            "check_result_schema": CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH,
+            "ok": False,
+            "strict_ok": False,
+            "summary": {
+                "recommendations": 0,
+                "errors": 0,
+                "warnings": 1,
+            },
+            "simulators": [],
+            "site": "",
+            "management": codex_plugin_management_policy(),
+            "recommendations": [],
+            "delegated_capabilities": {},
+            "collection_issues": [],
+            "issues": [],
+        }

--- a/src/runops/core/lint/plugins.py
+++ b/src/runops/core/lint/plugins.py
@@ -1,0 +1,52 @@
+"""Codex plugin recommendation checks for ``runo lint``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from runops.core.lint.models import LintContext, LintIssue
+from runops.core.plugins import check_project_codex_plugins
+
+
+def check_plugins(context: LintContext) -> list[LintIssue]:
+    """Check project-side Codex plugin recommendation metadata."""
+    issues: list[LintIssue] = []
+    result = check_project_codex_plugins(context.project_root)
+    for plugin_issue in result.issues:
+        issues.append(
+            LintIssue(
+                severity=plugin_issue.severity,
+                issue_id=f"plugins.metadata_{plugin_issue.severity}",
+                path=_issue_path(context.project_root, plugin_issue.source),
+                message=(
+                    f"{plugin_issue.plugin_name}.{plugin_issue.field}: "
+                    f"{plugin_issue.message}"
+                    + (
+                        f" Source: {plugin_issue.source}."
+                        if plugin_issue.source
+                        else ""
+                    )
+                ),
+                recommendation=(
+                    "Fix the project-side Codex plugin recommendation metadata, "
+                    "then run `runo plugins --check` again. runops does not "
+                    "install or enable user-local Codex plugins."
+                ),
+            )
+        )
+    return issues
+
+
+def _issue_path(project_root: Path, source: str) -> Path | None:
+    """Return the most likely project file for a plugin recommendation source."""
+    sources = [part.strip() for part in source.split(",") if part.strip()]
+    if len(sources) != 1:
+        return None
+    source = sources[0]
+    if source.startswith("site:"):
+        return project_root / "site.toml"
+    if source.startswith("simulator:"):
+        return project_root / "simulators.toml"
+    if source.startswith("project:"):
+        return project_root / "runops.toml"
+    return None

--- a/src/runops/core/lint/registry.py
+++ b/src/runops/core/lint/registry.py
@@ -10,6 +10,7 @@ from runops.core.exceptions import SimctlError
 from runops.core.lint.analysis import check_analysis
 from runops.core.lint.knowledge import check_knowledge
 from runops.core.lint.models import LintContext, LintIssue, LintReport
+from runops.core.lint.plugins import check_plugins
 from runops.core.lint.runs import check_provenance, check_runs
 from runops.core.lint.structure import check_structure
 
@@ -54,6 +55,11 @@ _CHECKS: tuple[RegisteredLintCheck, ...] = (
         scope="knowledge",
         description="Research agenda and curated knowledge auditability.",
         check=check_knowledge,
+    ),
+    RegisteredLintCheck(
+        scope="plugins",
+        description="Codex plugin recommendation metadata.",
+        check=check_plugins,
     ),
 )
 

--- a/src/runops/core/plugins.py
+++ b/src/runops/core/plugins.py
@@ -1,0 +1,708 @@
+"""External plugin recommendation inventory for runops projects."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from runops.core.codex_plugin import (
+    CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_PATH,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+    CodexPluginRecommendation,
+    codex_plugin_from_mapping,
+    codex_plugin_management_policy,
+    unique_codex_plugins,
+)
+from runops.core.project import ProjectConfig, find_project_root, load_project
+from runops.core.site import SiteProfile, load_site_profile
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+PluginIssueSeverity = Literal["error", "warning"]
+_SITE_FILE = "site.toml"
+_KNOWN_VISIBILITIES = frozenset({"public", "private-or-gated"})
+_PLUGIN_CONFLICT_FIELDS = (
+    "display_name",
+    "reason",
+    "install_hint",
+    "activation_hint",
+    "visibility",
+)
+_INVALID_CAPABILITIES_MESSAGE = (
+    "Codex plugin capabilities must be a string or a TOML array of non-empty strings."
+)
+
+
+@dataclass(frozen=True)
+class CodexPluginInventory:
+    """Codex plugin recommendations for a runops project."""
+
+    project_name: str
+    project_dir: Path
+    simulator_names: tuple[str, ...]
+    site_name: str
+    recommendations: tuple[CodexPluginRecommendation, ...]
+    collection_issues: tuple[CodexPluginIssue, ...] = ()
+
+    def delegated_capabilities(self) -> dict[str, list[str]]:
+        """Return capability labels mapped to recommending plugin names."""
+        return delegated_codex_plugin_capabilities(self.recommendations)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "$schema": CODEX_PLUGIN_INVENTORY_SCHEMA_PATH,
+            "schema_version": CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+            "project": {
+                "name": self.project_name,
+                "root": str(self.project_dir),
+            },
+            "simulators": list(self.simulator_names),
+            "site": self.site_name,
+            "management": codex_plugin_management_policy(),
+            "recommendations": [plugin.to_dict() for plugin in self.recommendations],
+            "delegated_capabilities": self.delegated_capabilities(),
+            "collection_issues": [issue.to_dict() for issue in self.collection_issues],
+        }
+
+
+@dataclass(frozen=True)
+class CodexPluginIssue:
+    """Validation issue for an advisory Codex plugin recommendation."""
+
+    severity: PluginIssueSeverity
+    plugin_name: str
+    field: str
+    message: str
+    source: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-serializable representation."""
+        return {
+            "severity": self.severity,
+            "plugin_name": self.plugin_name,
+            "field": self.field,
+            "message": self.message,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class CodexPluginCheckResult:
+    """Validation result for a project Codex plugin inventory."""
+
+    inventory: CodexPluginInventory
+    issues: tuple[CodexPluginIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        """Return whether no error-level issues were found."""
+        return not any(issue.severity == "error" for issue in self.issues)
+
+    def ok_with_strict(self) -> bool:
+        """Return whether no error or warning issues were found."""
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        errors = sum(1 for issue in self.issues if issue.severity == "error")
+        warnings = sum(1 for issue in self.issues if issue.severity == "warning")
+        return {
+            "$schema": CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH,
+            "schema_version": CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+            "ok": self.ok,
+            "strict_ok": self.ok_with_strict(),
+            "summary": {
+                "recommendations": len(self.inventory.recommendations),
+                "errors": errors,
+                "warnings": warnings,
+            },
+            "inventory": self.inventory.to_dict(),
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+
+
+def adapter_lookup_names(
+    simulator_names: Sequence[str],
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+) -> list[str]:
+    """Return adapter registry keys for simulator names and optional configs."""
+    return [
+        adapter_name
+        for _simulator_name, adapter_name in adapter_lookup_entries(
+            simulator_names,
+            simulator_configs,
+        )
+    ]
+
+
+def adapter_lookup_entries(
+    simulator_names: Sequence[str],
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+) -> list[tuple[str, str]]:
+    """Return unique ``(simulator_name, adapter_name)`` lookup entries."""
+    configs = simulator_configs or {}
+    seen: set[str] = set()
+    entries: list[tuple[str, str]] = []
+    for simulator_name in simulator_names:
+        config = configs.get(simulator_name, {})
+        adapter_name = simulator_name
+        if isinstance(config, dict):
+            configured = config.get("adapter")
+            if isinstance(configured, str) and configured:
+                adapter_name = configured
+        if adapter_name in seen:
+            continue
+        seen.add(adapter_name)
+        entries.append((simulator_name, adapter_name))
+    return entries
+
+
+def _collect_adapter_codex_plugins_raw(
+    simulator_names: Sequence[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+) -> list[CodexPluginRecommendation]:
+    """Return Codex plugins recommended by selected adapters before de-duping."""
+    recommendations, _issues = _collect_adapter_codex_plugins_with_issues(
+        simulator_names,
+        simulator_configs=simulator_configs,
+    )
+    return recommendations
+
+
+def _collect_adapter_codex_plugins_with_issues(
+    simulator_names: Sequence[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[CodexPluginRecommendation], list[CodexPluginIssue]]:
+    """Return adapter plugin recommendations and collection warnings."""
+    import runops.adapters  # noqa: F401
+    from runops.adapters.registry import get_global_registry
+
+    registry = get_global_registry()
+    plugins: list[CodexPluginRecommendation] = []
+    issues: list[CodexPluginIssue] = []
+    for simulator_name, adapter_name in adapter_lookup_entries(
+        simulator_names,
+        simulator_configs,
+    ):
+        try:
+            adapter_cls = registry.get(adapter_name)
+        except KeyError:
+            issues.append(
+                CodexPluginIssue(
+                    severity="warning",
+                    plugin_name=adapter_name,
+                    field="adapter",
+                    message=(
+                        f"Adapter '{adapter_name}' is not registered; "
+                        "adapter-declared Codex plugin recommendations for simulator "
+                        f"'{simulator_name}' could not be collected."
+                    ),
+                    source=f"simulator:{simulator_name}",
+                )
+            )
+            continue
+        source = f"simulator:{simulator_name}"
+        plugins.extend(
+            recommendation.with_additional_source(source)
+            for recommendation in adapter_cls.codex_plugins()
+        )
+    return plugins, issues
+
+
+def _collect_codex_plugin_metadata_issues(
+    plugin_name: str,
+    plugin_data: dict[str, Any],
+    *,
+    source: str,
+) -> list[CodexPluginIssue]:
+    """Return warnings for malformed optional plugin metadata fields."""
+    if _valid_capabilities_value(plugin_data.get("capabilities")):
+        return []
+    return [
+        CodexPluginIssue(
+            severity="warning",
+            plugin_name=plugin_name,
+            field="capabilities",
+            message=_INVALID_CAPABILITIES_MESSAGE,
+            source=source,
+        )
+    ]
+
+
+def _valid_capabilities_value(value: Any) -> bool:
+    """Return whether a raw ``capabilities`` metadata value is valid."""
+    if value is None or value == "":
+        return True
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple)):
+        return all(isinstance(item, str) and item.strip() for item in value)
+    return False
+
+
+def _collect_simulator_config_codex_plugins(
+    simulator_names: Sequence[str],
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[CodexPluginRecommendation], list[CodexPluginIssue]]:
+    """Return Codex plugin recommendations declared in simulator config."""
+    configs = simulator_configs or {}
+    recommendations: list[CodexPluginRecommendation] = []
+    issues: list[CodexPluginIssue] = []
+    for simulator_name in simulator_names:
+        config = configs.get(simulator_name, {})
+        if not isinstance(config, dict):
+            continue
+        plugins_raw = config.get("codex_plugins", {})
+        if plugins_raw in ({}, None):
+            continue
+        source = f"simulator:{simulator_name}"
+        if not isinstance(plugins_raw, dict):
+            issues.append(
+                CodexPluginIssue(
+                    severity="warning",
+                    plugin_name=simulator_name,
+                    field="codex_plugins",
+                    message=(
+                        "Simulator-level Codex plugin recommendations must be "
+                        "declared as a TOML table."
+                    ),
+                    source=source,
+                )
+            )
+            continue
+        for plugin_name, plugin_data in plugins_raw.items():
+            if not isinstance(plugin_data, dict):
+                issues.append(
+                    CodexPluginIssue(
+                        severity="warning",
+                        plugin_name=str(plugin_name),
+                        field="codex_plugins",
+                        message=(
+                            "Simulator-level Codex plugin recommendation metadata "
+                            "must be a TOML table."
+                        ),
+                        source=source,
+                    )
+                )
+                continue
+            issues.extend(
+                _collect_codex_plugin_metadata_issues(
+                    str(plugin_name),
+                    plugin_data,
+                    source=source,
+                )
+            )
+            recommendations.append(
+                codex_plugin_from_mapping(
+                    str(plugin_name),
+                    plugin_data,
+                    source=source,
+                )
+            )
+    return recommendations, issues
+
+
+def _collect_project_config_codex_plugins(
+    project: ProjectConfig,
+) -> tuple[list[CodexPluginRecommendation], list[CodexPluginIssue]]:
+    """Return project-wide Codex plugin recommendations from ``runops.toml``."""
+    project_section = project.raw.get("project", {})
+    if not isinstance(project_section, dict):
+        return [], []
+
+    plugins_raw = project_section.get("codex_plugins", {})
+    if plugins_raw in ({}, None):
+        return [], []
+
+    source = f"project:{project.name}"
+    if not isinstance(plugins_raw, dict):
+        return [], [
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=project.name,
+                field="codex_plugins",
+                message=(
+                    "Project-level Codex plugin recommendations must be "
+                    "declared as a TOML table."
+                ),
+                source=source,
+            )
+        ]
+
+    recommendations: list[CodexPluginRecommendation] = []
+    issues: list[CodexPluginIssue] = []
+    for plugin_name, plugin_data in plugins_raw.items():
+        if not isinstance(plugin_data, dict):
+            issues.append(
+                CodexPluginIssue(
+                    severity="warning",
+                    plugin_name=str(plugin_name),
+                    field="codex_plugins",
+                    message=(
+                        "Project-level Codex plugin recommendation metadata "
+                        "must be a TOML table."
+                    ),
+                    source=source,
+                )
+            )
+            continue
+        issues.extend(
+            _collect_codex_plugin_metadata_issues(
+                str(plugin_name),
+                plugin_data,
+                source=source,
+            )
+        )
+        recommendations.append(
+            codex_plugin_from_mapping(
+                str(plugin_name),
+                plugin_data,
+                source=source,
+            )
+        )
+    return recommendations, issues
+
+
+def _collect_site_config_codex_plugin_issues(
+    project_root: Path,
+    *,
+    site_name: str,
+) -> list[CodexPluginIssue]:
+    """Return site-level Codex plugin collection warnings from ``site.toml``."""
+    site_file = project_root / _SITE_FILE
+    if not site_file.is_file():
+        return []
+
+    with open(site_file, "rb") as f:
+        raw = tomllib.load(f)
+    site = raw.get("site", {})
+    if not isinstance(site, dict):
+        return []
+
+    plugins_raw = site.get("codex_plugins", {})
+    if plugins_raw in ({}, None):
+        return []
+
+    source = f"site:{site.get('name') or site_name or site_file.stem}"
+    if not isinstance(plugins_raw, dict):
+        return [
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=str(site.get("name") or site_name or "site"),
+                field="codex_plugins",
+                message=(
+                    "Site-level Codex plugin recommendations must be declared "
+                    "as a TOML table."
+                ),
+                source=source,
+            )
+        ]
+
+    issues: list[CodexPluginIssue] = []
+    for plugin_name, plugin_data in plugins_raw.items():
+        if isinstance(plugin_data, dict):
+            issues.extend(
+                _collect_codex_plugin_metadata_issues(
+                    str(plugin_name),
+                    plugin_data,
+                    source=source,
+                )
+            )
+            continue
+        issues.append(
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=str(plugin_name),
+                field="codex_plugins",
+                message=(
+                    "Site-level Codex plugin recommendation metadata must be "
+                    "a TOML table."
+                ),
+                source=source,
+            )
+        )
+    return issues
+
+
+def collect_adapter_codex_plugins(
+    simulator_names: Sequence[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+) -> list[CodexPluginRecommendation]:
+    """Return unique Codex plugins recommended by selected adapters."""
+    return unique_codex_plugins(
+        _collect_adapter_codex_plugins_raw(
+            simulator_names,
+            simulator_configs=simulator_configs,
+        )
+    )
+
+
+def _collect_codex_plugin_recommendations_raw(
+    simulator_names: Sequence[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+    project_plugins: Sequence[CodexPluginRecommendation] | None = None,
+    site_profile: SiteProfile | None = None,
+    extra_plugins: Sequence[CodexPluginRecommendation] | None = None,
+) -> list[CodexPluginRecommendation]:
+    """Collect Codex plugin recommendations before de-duping."""
+    recommendations, _issues = _collect_codex_plugin_recommendations_with_issues(
+        simulator_names,
+        simulator_configs=simulator_configs,
+        project_plugins=project_plugins,
+        site_profile=site_profile,
+        extra_plugins=extra_plugins,
+    )
+    return recommendations
+
+
+def _collect_codex_plugin_recommendations_with_issues(
+    simulator_names: Sequence[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+    project_plugins: Sequence[CodexPluginRecommendation] | None = None,
+    site_profile: SiteProfile | None = None,
+    extra_plugins: Sequence[CodexPluginRecommendation] | None = None,
+) -> tuple[list[CodexPluginRecommendation], list[CodexPluginIssue]]:
+    """Collect raw Codex plugin recommendations and collection warnings."""
+    recommendations: list[CodexPluginRecommendation] = []
+    adapter_recommendations, issues = _collect_adapter_codex_plugins_with_issues(
+        simulator_names,
+        simulator_configs=simulator_configs,
+    )
+    config_recommendations, config_issues = _collect_simulator_config_codex_plugins(
+        simulator_names,
+        simulator_configs=simulator_configs,
+    )
+    recommendations.extend(adapter_recommendations)
+    recommendations.extend(config_recommendations)
+    issues.extend(config_issues)
+    if project_plugins:
+        recommendations.extend(project_plugins)
+    if site_profile is not None:
+        recommendations.extend(site_profile.codex_plugins)
+    if extra_plugins:
+        recommendations.extend(extra_plugins)
+    return recommendations, issues
+
+
+def collect_codex_plugin_recommendations(
+    simulator_names: Sequence[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
+    project_plugins: Sequence[CodexPluginRecommendation] | None = None,
+    site_profile: SiteProfile | None = None,
+    extra_plugins: Sequence[CodexPluginRecommendation] | None = None,
+) -> list[CodexPluginRecommendation]:
+    """Collect unique Codex plugin recommendations."""
+    recommendations = _collect_codex_plugin_recommendations_raw(
+        simulator_names,
+        simulator_configs=simulator_configs,
+        project_plugins=project_plugins,
+        site_profile=site_profile,
+        extra_plugins=extra_plugins,
+    )
+    return unique_codex_plugins(recommendations)
+
+
+def delegated_codex_plugin_capabilities(
+    recommendations: Sequence[CodexPluginRecommendation],
+) -> dict[str, list[str]]:
+    """Return a stable capability-to-plugin index for recommendations."""
+    index: dict[str, list[str]] = {}
+    for recommendation in recommendations:
+        for capability in recommendation.capabilities:
+            capability_name = capability.strip()
+            if not capability_name:
+                continue
+            plugin_names = index.setdefault(capability_name, [])
+            if recommendation.name not in plugin_names:
+                plugin_names.append(recommendation.name)
+    return {capability: index[capability] for capability in sorted(index)}
+
+
+def _plugin_metadata(plugin: CodexPluginRecommendation) -> dict[str, Any]:
+    """Return metadata fields that must agree for duplicate recommendations."""
+    return {
+        "display_name": plugin.display_name,
+        "reason": plugin.reason,
+        "install_hint": plugin.install_hint,
+        "activation_hint": plugin.activation_hint,
+        "visibility": plugin.visibility,
+        "capabilities": plugin.capabilities,
+    }
+
+
+def detect_codex_plugin_conflicts(
+    recommendations: Sequence[CodexPluginRecommendation],
+) -> list[CodexPluginIssue]:
+    """Return warnings for duplicate plugin names with conflicting metadata."""
+    seen: dict[str, CodexPluginRecommendation] = {}
+    issues: list[CodexPluginIssue] = []
+    for recommendation in recommendations:
+        existing = seen.get(recommendation.name)
+        if existing is None:
+            seen[recommendation.name] = recommendation
+            continue
+
+        existing_metadata = _plugin_metadata(existing)
+        candidate_metadata = _plugin_metadata(recommendation)
+        changed_fields = [
+            field
+            for field in _PLUGIN_CONFLICT_FIELDS
+            if existing_metadata[field] != candidate_metadata[field]
+        ]
+        if not changed_fields:
+            continue
+
+        sources = [
+            source for source in (existing.source, recommendation.source) if source
+        ]
+        issues.append(
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=recommendation.name or "<unnamed>",
+                field="duplicate",
+                message=(
+                    "Multiple sources recommend this Codex plugin with "
+                    "different metadata. The first recommendation is used. "
+                    f"Differing fields: {', '.join(changed_fields)}."
+                ),
+                source=", ".join(sources),
+            )
+        )
+    return issues
+
+
+def validate_codex_plugin_recommendation(
+    plugin: CodexPluginRecommendation,
+) -> list[CodexPluginIssue]:
+    """Validate advisory metadata for one Codex plugin recommendation."""
+    plugin_name = plugin.name or "<unnamed>"
+    issues: list[CodexPluginIssue] = []
+    required_fields = {
+        "name": plugin.name,
+        "display_name": plugin.display_name,
+        "reason": plugin.reason,
+        "install_hint": plugin.install_hint,
+    }
+    for field, value in required_fields.items():
+        if not value.strip():
+            issues.append(
+                CodexPluginIssue(
+                    severity="error",
+                    plugin_name=plugin_name,
+                    field=field,
+                    message=(
+                        "Codex plugin recommendations must include enough "
+                        "metadata for users to decide and install manually."
+                    ),
+                    source=plugin.source,
+                )
+            )
+
+    if plugin.visibility not in _KNOWN_VISIBILITIES:
+        issues.append(
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=plugin_name,
+                field="visibility",
+                message=(
+                    "Unknown visibility; expected 'public' or 'private-or-gated'."
+                ),
+                source=plugin.source,
+            )
+        )
+    if not plugin.activation_hint.strip():
+        issues.append(
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=plugin_name,
+                field="activation_hint",
+                message=(
+                    "Activation hint is empty; users may not know how to enable it."
+                ),
+                source=plugin.source,
+            )
+        )
+    if not plugin.source.strip():
+        issues.append(
+            CodexPluginIssue(
+                severity="warning",
+                plugin_name=plugin_name,
+                field="source",
+                message="Source is empty; generated diagnostics cannot show origin.",
+                source=plugin.source,
+            )
+        )
+    return issues
+
+
+def check_codex_plugin_inventory(
+    inventory: CodexPluginInventory,
+) -> CodexPluginCheckResult:
+    """Validate advisory plugin recommendation metadata for an inventory."""
+    issues: list[CodexPluginIssue] = list(inventory.collection_issues)
+    for plugin in inventory.recommendations:
+        issues.extend(validate_codex_plugin_recommendation(plugin))
+    return CodexPluginCheckResult(inventory=inventory, issues=tuple(issues))
+
+
+def build_project_codex_plugin_inventory(
+    project: ProjectConfig,
+) -> CodexPluginInventory:
+    """Build a Codex plugin inventory for an already-loaded project."""
+    site_profile = load_site_profile(project.root_dir)
+    simulator_names = tuple(project.simulators.keys())
+    project_recommendations, project_issues = _collect_project_config_codex_plugins(
+        project
+    )
+    site_issues = _collect_site_config_codex_plugin_issues(
+        project.root_dir,
+        site_name=site_profile.name,
+    )
+    raw_recommendations, collection_issues = (
+        _collect_codex_plugin_recommendations_with_issues(
+            simulator_names,
+            simulator_configs=project.simulators,
+            project_plugins=project_recommendations,
+            site_profile=site_profile,
+        )
+    )
+    recommendations = unique_codex_plugins(raw_recommendations)
+    return CodexPluginInventory(
+        project_name=project.name,
+        project_dir=project.root_dir,
+        simulator_names=simulator_names,
+        site_name=site_profile.name,
+        recommendations=tuple(recommendations),
+        collection_issues=tuple(
+            collection_issues
+            + project_issues
+            + site_issues
+            + detect_codex_plugin_conflicts(raw_recommendations)
+        ),
+    )
+
+
+def load_project_codex_plugin_inventory(path: Path) -> CodexPluginInventory:
+    """Find a project and return its Codex plugin recommendation inventory."""
+    project_dir = find_project_root(path)
+    project = load_project(project_dir)
+    return build_project_codex_plugin_inventory(project)
+
+
+def check_project_codex_plugins(path: Path) -> CodexPluginCheckResult:
+    """Find a project and validate its advisory plugin recommendation metadata."""
+    return check_codex_plugin_inventory(load_project_codex_plugin_inventory(path))

--- a/src/runops/core/site/profile.py
+++ b/src/runops/core/site/profile.py
@@ -38,6 +38,9 @@ else:
 logger = logging.getLogger(__name__)
 
 _SITE_FILE = "site.toml"
+_SITE_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/Nkzono99/runops/main/schemas/site.json"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -360,17 +363,12 @@ def save_site_profile(project_root: Path, profile: SiteProfile) -> Path:
     if profile.codex_plugins:
         plugins: dict[str, Any] = {}
         for plugin in profile.codex_plugins:
-            plugins[plugin.name] = {
-                "display_name": plugin.display_name,
-                "visibility": plugin.visibility,
-                "reason": plugin.reason,
-                "install_hint": plugin.install_hint,
-                "activation_hint": plugin.activation_hint,
-            }
+            plugins[plugin.name] = plugin.to_site_mapping()
         site["codex_plugins"] = plugins
 
     site_file = project_root / _SITE_FILE
     with open(site_file, "wb") as f:
+        f.write(f"#:schema {_SITE_SCHEMA_URL}\n".encode())
         tomli_w.dump(data, f)
 
     return site_file

--- a/src/runops/harness/_adapters.py
+++ b/src/runops/harness/_adapters.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from runops.core.codex_plugin import CodexPluginRecommendation
+from runops.core.plugins import collect_adapter_codex_plugins
 
 
 def collect_doc_repos(simulator_names: list[str]) -> list[tuple[str, str]]:
@@ -49,22 +52,11 @@ def collect_pip_packages(simulator_names: list[str]) -> list[str]:
 
 def collect_codex_plugins(
     simulator_names: list[str],
+    *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
 ) -> list[CodexPluginRecommendation]:
     """Return unique Codex plugins recommended by the given adapters."""
-    import runops.adapters  # noqa: F401
-    from runops.adapters.registry import get_global_registry
-
-    registry = get_global_registry()
-    seen: set[str] = set()
-    plugins: list[CodexPluginRecommendation] = []
-    for sim_name in simulator_names:
-        try:
-            adapter_cls = registry.get(sim_name)
-        except KeyError:
-            continue
-        for plugin in adapter_cls.codex_plugins():
-            if plugin.name in seen:
-                continue
-            seen.add(plugin.name)
-            plugins.append(plugin)
-    return plugins
+    return collect_adapter_codex_plugins(
+        simulator_names,
+        simulator_configs=simulator_configs,
+    )

--- a/src/runops/harness/_plugins.py
+++ b/src/runops/harness/_plugins.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
-from runops.core.codex_plugin import (
-    CodexPluginRecommendation,
-    unique_codex_plugins,
+from runops.core.codex_plugin import CodexPluginRecommendation
+from runops.core.plugins import (
+    collect_codex_plugin_recommendations,
 )
 from runops.core.site import SiteProfile, load_site_profile
-from runops.harness._adapters import collect_codex_plugins
 
 
 def load_site_profile_for_recommendations(project_dir: Path) -> SiteProfile | None:
@@ -23,18 +23,17 @@ def load_site_profile_for_recommendations(project_dir: Path) -> SiteProfile | No
 def collect_plugin_recommendations(
     simulator_names: list[str],
     *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
     site_profile: SiteProfile | None = None,
     extra_plugins: list[CodexPluginRecommendation] | None = None,
 ) -> list[CodexPluginRecommendation]:
     """Collect unique plugin recommendations for simulator and site choices."""
-    recommendations: list[CodexPluginRecommendation] = []
-    if simulator_names:
-        recommendations.extend(collect_codex_plugins(simulator_names))
-    if site_profile is not None:
-        recommendations.extend(site_profile.codex_plugins)
-    if extra_plugins:
-        recommendations.extend(extra_plugins)
-    return unique_codex_plugins(recommendations)
+    return collect_codex_plugin_recommendations(
+        simulator_names,
+        simulator_configs=simulator_configs,
+        site_profile=site_profile,
+        extra_plugins=extra_plugins,
+    )
 
 
 def echo_plugin_recommendations(
@@ -56,6 +55,8 @@ def echo_plugin_recommendations(
         typer.echo(f"  - {plugin.display_name} (`{plugin.name}`){visibility}")
         if plugin.reason:
             typer.echo(f"    Why: {plugin.reason}")
+        if plugin.capabilities:
+            typer.echo(f"    Capabilities: {', '.join(plugin.capabilities)}")
         if plugin.install_hint:
             typer.echo("    Install:")
             for line in plugin.install_hint.strip().splitlines():

--- a/src/runops/harness/builder.py
+++ b/src/runops/harness/builder.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from runops import __version__
 from runops.core.codex_plugin import CodexPluginRecommendation
-from runops.harness._adapters import collect_codex_plugins as _collect_codex_plugins
+from runops.core.plugins import collect_adapter_codex_plugins
 from runops.harness._adapters import collect_doc_repos as _collect_doc_repos
 from runops.harness._skills import render_skill_files as _render_skill_files
 
@@ -261,6 +261,7 @@ def build_harness_bundle(
     project_name: str,
     simulator_names: list[str],
     *,
+    simulator_configs: dict[str, dict[str, Any]] | None = None,
     upstream_feedback: bool = True,
     knowledge_imports_path: str = "",
     include_reference_repos: bool = False,
@@ -271,6 +272,9 @@ def build_harness_bundle(
     Args:
         project_name: Project name used in CLAUDE.md / AGENTS.md headers.
         simulator_names: Simulator adapter names (e.g. ``["emses", "beach"]``).
+        simulator_configs: Optional project simulator config keyed by simulator
+            name.  When present, ``adapter = "..."`` aliases are used for
+            adapter-declared fallback recommendations.
         upstream_feedback: Include the ``.claude/rules/upstream-feedback.md``
             rule.  ``runops init --no-upstream-feedback`` sets this to False.
         knowledge_imports_path: Relative path to the rendered imports file,
@@ -302,7 +306,10 @@ def build_harness_bundle(
     )
     include_cookbook_rule = bool(simulator_names and doc_repos)
     plugin_recommendations = (
-        _collect_codex_plugins(simulator_names)
+        collect_adapter_codex_plugins(
+            simulator_names,
+            simulator_configs=simulator_configs,
+        )
         if codex_plugin_recommendations is None
         else codex_plugin_recommendations
     )

--- a/src/runops/mcp/registry.py
+++ b/src/runops/mcp/registry.py
@@ -7,6 +7,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from runops.core.actions.specs import ACTION_SPECS
+from runops.core.codex_plugin import (
+    CODEX_PLUGIN_ACTIVATION_SCOPE,
+    CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_PATH,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+)
 from runops.mcp.safety import (
     DESTRUCTIVE_DISABLED,
     EXTERNAL_DISABLED,
@@ -72,6 +78,11 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         "runops.project.inspect",
         "Return detailed local project metadata and agent context.",
         INSPECT,
+    ),
+    ToolSpec(
+        "runops.project.plugins",
+        "Return advisory Codex plugin recommendations and metadata checks.",
+        READ,
     ),
     ToolSpec(
         "runops.project.doctor",
@@ -159,6 +170,55 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
     ),
 )
 
+CODEX_PLUGIN_POLICY: dict[str, Any] = {
+    "recommendations_advisory": True,
+    "metadata_checks_supported": True,
+    "installs_plugins": False,
+    "enables_plugins": False,
+    "inspects_user_install_state": False,
+    "activation_scope": CODEX_PLUGIN_ACTIVATION_SCOPE,
+    "inventory_schema_version": CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+    "inventory_schema": CODEX_PLUGIN_INVENTORY_SCHEMA_PATH,
+    "check_result_schema": CODEX_PLUGIN_CHECK_RESULT_SCHEMA_PATH,
+    "project_tool": "runops.project.plugins",
+    "inventory_fields": [
+        "$schema",
+        "schema_version",
+        "project",
+        "simulators",
+        "site",
+        "management",
+        "recommendations",
+        "delegated_capabilities",
+        "collection_issues",
+    ],
+    "check_result_fields": [
+        "$schema",
+        "schema_version",
+        "ok",
+        "strict_ok",
+        "summary",
+        "inventory",
+        "issues",
+    ],
+    "recommendation_fields": [
+        "name",
+        "display_name",
+        "reason",
+        "install_hint",
+        "activation_hint",
+        "visibility",
+        "source",
+        "sources",
+        "capabilities",
+    ],
+    "source_fields": {
+        "source": "legacy comma-separated source label string",
+        "sources": "machine-readable source label list",
+    },
+    "delegated_capabilities_field": "delegated_capabilities",
+}
+
 REQUIRED_COMMON_TOOLS = {
     "runops.health",
     "runops.provider.info",
@@ -175,6 +235,7 @@ REQUIRED_RUNOPS_TOOLS = REQUIRED_COMMON_TOOLS | {
     "runops.paper.request.draft",
     "runops.paper.request.plan",
     "runops.paper.requests.list",
+    "runops.project.plugins",
     "runops.publication.export.inspect",
     "runops.publication.exports.list",
     "runops.run.list",
@@ -218,6 +279,7 @@ def capabilities_payload() -> dict[str, Any]:
         },
         "tools": [spec.to_dict() for spec in TOOL_SPECS],
         "transports": ["stdio", "streamable-http"],
+        "codex_plugin_policy": CODEX_PLUGIN_POLICY,
     }
 
 

--- a/src/runops/mcp/server.py
+++ b/src/runops/mcp/server.py
@@ -94,6 +94,17 @@ def _register_tools(mcp: FastMCP) -> None:
         return tools.project_inspect(project_root=project_root)
 
     @mcp.tool(
+        name="runops.project.plugins",
+        description="Return advisory Codex plugin recommendations and metadata checks.",
+        structured_output=True,
+    )
+    def project_plugins(
+        project_root: str | None = None,
+        strict: bool = False,
+    ) -> dict[str, Any]:
+        return tools.project_plugins(project_root=project_root, strict=strict)
+
+    @mcp.tool(
         name="runops.project.doctor",
         description="Diagnose project configuration without mutating files.",
         structured_output=True,

--- a/src/runops/mcp/tools.py
+++ b/src/runops/mcp/tools.py
@@ -19,10 +19,12 @@ from runops.core.context import build_project_context
 from runops.core.discovery import discover_runs, resolve_run, validate_uniqueness
 from runops.core.exceptions import SimctlError
 from runops.core.manifest import ManifestData, read_manifest
+from runops.core.plugins import check_project_codex_plugins
 from runops.core.project import ProjectConfig, find_project_root, load_project
 from runops.core.readiness import evaluate_run_readiness
 from runops.core.state import RunState
 from runops.mcp.registry import (
+    CODEX_PLUGIN_POLICY,
     capabilities_payload,
     exposed_tool_specs,
     tool_spec,
@@ -602,6 +604,7 @@ def provider_info() -> dict[str, Any]:
             "provider_version": __version__,
             "contract_version": CONTRACT_VERSION,
             "supported_transports": ["stdio", "streamable-http"],
+            "codex_plugin_policy": CODEX_PLUGIN_POLICY,
             "default_policy": {
                 "read_enabled": True,
                 "plan_enabled": True,
@@ -741,6 +744,85 @@ def project_inspect(project_root: str | None = None) -> dict[str, Any]:
     )
 
 
+def project_plugins(
+    project_root: str | None = None,
+    strict: bool = False,
+) -> dict[str, Any]:
+    """Return advisory Codex plugin recommendations and metadata checks."""
+    started_at, started_perf = _tool_start()
+    spec = tool_spec("runops.project.plugins")
+    inputs = {"project_root": project_root, "strict": strict}
+    try:
+        root = _resolve_project_root(project_root)
+        check_result = check_project_codex_plugins(root)
+    except Exception as exc:
+        return blocked_envelope(
+            tool=spec.name,
+            safety=spec.safety,
+            code="project_plugins_failed",
+            message=str(exc),
+            inputs=inputs,
+        )
+
+    errors_count = sum(1 for issue in check_result.issues if issue.severity == "error")
+    warnings_count = sum(
+        1 for issue in check_result.issues if issue.severity == "warning"
+    )
+    data = check_result.to_dict()
+    data["strict"] = strict
+
+    mcp_errors: list[dict[str, Any]] = []
+    mcp_warnings: list[dict[str, Any]] = []
+    for issue in check_result.issues:
+        message = f"{issue.plugin_name}.{issue.field}: {issue.message}"
+        if issue.source:
+            message += f" Source: {issue.source}."
+        if issue.severity == "error":
+            mcp_errors.append(error("codex_plugin_metadata_error", message))
+        else:
+            mcp_warnings.append(
+                warning(
+                    "codex_plugin_metadata_warning",
+                    message,
+                    severity="high" if strict else "medium",
+                )
+            )
+
+    if errors_count:
+        status: EnvelopeStatus = "error"
+        summary = (
+            "Codex plugin recommendation metadata has "
+            f"{errors_count} error(s) and {warnings_count} warning(s)."
+        )
+    elif warnings_count:
+        status = "warning"
+        summary = (
+            f"Codex plugin recommendation metadata has {warnings_count} warning(s)."
+        )
+        if strict:
+            summary += " Strict metadata check is not clean."
+    else:
+        status = "ok"
+        recommendation_count = len(check_result.inventory.recommendations)
+        summary = (
+            f"{recommendation_count} Codex plugin recommendation(s); metadata is OK."
+        )
+
+    return envelope(
+        tool=spec.name,
+        safety=spec.safety,
+        status=status,
+        summary=summary,
+        data=data,
+        project_root=root,
+        warnings=mcp_warnings,
+        errors=mcp_errors,
+        started_at=started_at,
+        started_perf=started_perf,
+        inputs=inputs,
+    )
+
+
 def project_doctor(project_root: str | None = None) -> dict[str, Any]:
     """Diagnose project configuration without mutating files."""
     started_at, started_perf = _tool_start()
@@ -807,6 +889,43 @@ def project_doctor(project_root: str | None = None) -> dict[str, Any]:
         add("campaign.toml", True, "campaign.toml found")
     else:
         add("campaign.toml", True, "campaign.toml is optional and missing")
+
+    try:
+        plugin_check = check_project_codex_plugins(root)
+        errors_count = sum(
+            1 for issue in plugin_check.issues if issue.severity == "error"
+        )
+        warnings_count = sum(
+            1 for issue in plugin_check.issues if issue.severity == "warning"
+        )
+        if errors_count:
+            add(
+                "codex_plugins",
+                False,
+                "Codex plugin recommendation metadata has "
+                f"{errors_count} error(s) and {warnings_count} warning(s).",
+                severity="medium",
+            )
+        elif warnings_count:
+            add(
+                "codex_plugins",
+                True,
+                "Codex plugin recommendation metadata has "
+                f"{warnings_count} warning(s); inspect runops.project.plugins.",
+            )
+        else:
+            add(
+                "codex_plugins",
+                True,
+                "Codex plugin recommendation metadata is OK.",
+            )
+    except Exception as exc:
+        add(
+            "codex_plugins",
+            False,
+            f"Codex plugin recommendation metadata check failed: {exc}",
+            severity="medium",
+        )
 
     failed = [check for check in checks if not check["ok"]]
     summary = "All checks passed." if not failed else f"{len(failed)} check(s) failed."

--- a/src/runops/sites/camphor.toml
+++ b/src/runops/sites/camphor.toml
@@ -1,3 +1,4 @@
+#:schema https://raw.githubusercontent.com/Nkzono99/runops/main/schemas/site.json
 # Camphor (Fujitsu PRIMEHPC / camphor3)
 # https://web.kudpc.kyoto-u.ac.jp/manual/ja
 
@@ -24,6 +25,13 @@ modules = [
 display_name = "KUDPC HPC"
 visibility = "private-or-gated"
 reason = "KUDPC host role routing, login/application/compute node safety, Slurm tssrun/sbatch/srun workflows, --rsc resources, Modules, and compile guidance."
+capabilities = [
+    "host-role-routing",
+    "safe-workflows",
+    "slurm-jobs",
+    "env-compile",
+    "hpc-feedback",
+]
 install_hint = """
 gh auth status
 gh auth setup-git

--- a/src/runops/templates/README.md
+++ b/src/runops/templates/README.md
@@ -17,7 +17,8 @@ Current layout:
 - `scaffold/` — generic project scaffold files that are not primarily agent
   harness files, such as `.gitignore`, `campaign.toml`, `notes/`,
   `materials/`, `research/`, and editor settings.
-- `adapters/` — simulator-specific case/input templates and adapter guides.
+- `adapters/` — simulator-specific case/input templates and minimal
+  plugin-first adapter fallback guides.
 - Root-level templates are legacy convenience paths. Avoid adding new files at
   the root; place them in the domain-specific directory instead.
 

--- a/src/runops/templates/adapters/beach/agent_guide.md
+++ b/src/runops/templates/adapters/beach/agent_guide.md
@@ -1,50 +1,39 @@
-### BEACH (BEM + Accumulated CHarge Simulator)
+### BEACH runops fallback guide
 
-#### 概要
-BEACH は境界要素法 (BEM) ベースの表面帯電シミュレーション。
-MPI + OpenMP ハイブリッド並列で実行し、宇宙機表面の帯電現象を計算する。
+This generated guide is intentionally small. BEACH-specific parameter design,
+configuration review, run diagnosis, output analysis, and visualization should
+come from the recommended external Codex plugin `BEACH Context`
+(`beach-context`) when it is available.
 
-#### 入力ファイル
-- **`input/beach.toml`** — メイン設定ファイル (TOML 形式)
-  - `[sim]`: `dt`, `max_step`, `batch_count`, `field_solver`
-  - `[mesh]`: `obj_path` (OBJ メッシュファイルパス)
-  - `[environment]`: プラズマ環境パラメータ (密度, 温度, etc.)
-  - `[output]`: `dir` (出力ディレクトリ)
+Before using this fallback, run:
 
-#### 出力ファイル (`work/latest/` 以下)
-- `summary.txt` — 計算結果サマリー (完了時に生成)
-- `charges.csv` — 表面電荷分布
-- `charge_history.csv` — 電荷時間履歴
-- `potential_history.csv` — 電位時間履歴
-- `mesh_triangles.csv`, `mesh_sources.csv` — メッシュ情報
-- `performance_profile.csv` — 性能プロファイル
-
-#### 完了判定
-- `work/latest/summary.txt` が存在 → completed
-- stderr に "error", "fatal", "killed" → failed
-- `charges.csv` のみ存在 → running (途中)
-
-#### パラメータサーベイでよく変えるパラメータ
-- `sim.dt`, `sim.max_step`, `sim.batch_count`
-- `environment.electron_density`, `environment.electron_temperature`
-- `environment.ion_density`, `environment.ion_temperature`
-- `mesh.obj_path` (異なるジオメトリの比較)
-
-#### ドキュメント・参考
-- BEACH ソースリポジトリの README / docs/
-- OBJ メッシュファイルは Blender 等で作成
-- パラメータの dot 記法例: `sim.dt=1.0e-6`, `environment.electron_density=1.0e12`
-
-#### 実行コマンド
-```
-srun beach input/beach.toml
+```bash
+uvx --from runops runo plugins --check
+uvx --from runops runo plugins --json
 ```
 
-`beach.toml` の `output.dir` は `work/latest` に自動設定される。
+Use the `delegated_capabilities` index to route BEACH work such as
+`config-review`, `case-design`, `run-diagnose`, `output-analysis`, and
+`visualization-script` to the plugin. runops does not install or enable the
+plugin; that remains user-local Codex state.
 
-#### 環境変数 (OpenMP)
-```
-OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
-OMP_PROC_BIND=spread
-OMP_PLACES=cores
-```
+#### runops responsibilities
+
+- Treat the run directory and `manifest.toml` as the source of truth.
+- Let the BEACH adapter render `input/beach.toml` and detect required outputs.
+- Keep `work/`, `input/`, `submit/`, and `manifest.toml` under runops control.
+- Use `runo create`, `runo submit`, `runo status`, `runo summarize`, and
+  `runo collect` instead of ad hoc file movement.
+
+#### Minimal fallback facts
+
+- Main rendered input: `input/beach.toml`.
+- Primary completion / summary file: `work/latest/summary.txt`.
+- Common output categories: charge CSVs, mesh CSVs, history CSVs, and summary
+  text. Use adapter-required output metadata for exact project checks.
+- For parameter meaning, numerical stability, physical interpretation, and
+  plotting details, prefer `BEACH Context`, enabled knowledge imports, project
+  materials, or BEACH upstream documentation.
+
+Do not treat this file as a full BEACH manual. It is only the runops-side
+handoff point when richer simulator context has not been installed or mounted.

--- a/src/runops/templates/adapters/emses/agent_guide.md
+++ b/src/runops/templates/adapters/emses/agent_guide.md
@@ -1,39 +1,42 @@
-### EMSES (Electromagnetic Particle-in-Cell Simulator)
+### EMSES runops fallback guide
 
-#### 概要
-EMSES は 3D 電磁粒子シミュレーション (PIC) コード。
-MPI 並列で実行し、電磁場と荷電粒子の自己無撞着な時間発展を計算する。
+This generated guide is intentionally small. MPIEMSES3D-specific input review,
+parameter design, run diagnosis, HDF5 output analysis, emout usage, and
+visualization should come from the recommended external Codex plugins
+`MPIEMSES3D Context` (`mpiemses3d-context`) and `emout Context`
+(`emout-context`) when they are available.
 
-#### 入力ファイル
-- **`input/plasma.toml`** — メイン設定ファイル (TOML 形式)
-  - `[jobcon]`: `nstep` (総ステップ数) が最重要パラメータ
-  - `[tmgrid]`: `nx`, `ny`, `nz` (グリッド数), `dt` (時間刻み)
-  - `[[species]]`: 粒子種の定義 (質量比, 温度, 密度 etc.)
-  - `[emfield]`: 外部磁場・電場の設定
-  - `[[ptcond.objects]]`: 境界条件・導体オブジェクト
+Before using this fallback, run:
 
-#### 出力ファイル (`work/latest/` 以下)
-- `*.h5` — HDF5 形式の電磁場データ (ex, ey, ez, bx, by, bz, etc.)
-- `energy` — エネルギー時系列 (ASCII)。最終行のステップ番号で完了判定
-- `SNAPSHOT1/esdat*.h5` — リスタート用スナップショット
-- 各種診断ファイル: `ewave`, `chgacm1`, `influx`, `icur` 等
-
-#### 完了判定
-- `work/latest/energy` の最終行のステップ番号 ≥ `nstep` → completed
-- stderr に "error", "segmentation fault", "killed" → failed
-
-#### パラメータサーベイでよく変えるパラメータ
-- `tmgrid.dt`, `tmgrid.nx/ny/nz`
-- `species[0].temperature`, `species[0].density`
-- `emfield.ex0`, `emfield.bx0` (外部場)
-- `jobcon.nstep`
-
-#### ドキュメント・参考
-- EMSES ソースリポジトリの README / docs/
-- `plasma.toml` のスキーマは `format_version = 2` (structured TOML)
-- パラメータの dot 記法例: `tmgrid.nx=128`, `species.0.temperature=1.0e6`
-
-#### 実行コマンド
+```bash
+uvx --from runops runo plugins --check
+uvx --from runops runo plugins --json
 ```
-srun mpiemses3D input/plasma.toml -o work/latest
-```
+
+Use the `delegated_capabilities` index to route work such as `input-review`,
+`parameter-design`, `run-diagnose`, `output-analysis`, and
+`visualization-script` to the relevant plugin. runops does not install or
+enable plugins; that remains user-local Codex state.
+
+#### runops responsibilities
+
+- Treat the run directory and `manifest.toml` as the source of truth.
+- Let the EMSES adapter render `input/plasma.toml` and detect required outputs.
+- Keep `work/`, `input/`, `submit/`, and `manifest.toml` under runops control.
+- Keep MPI launch behavior in launcher/job.sh layers. Python should not become
+  a rank wrapper.
+- Use `runo create`, `runo submit`, `runo status`, `runo summarize`, and
+  `runo collect` instead of ad hoc file movement.
+
+#### Minimal fallback facts
+
+- Main rendered input: `input/plasma.toml`.
+- Common output categories: stdout/stderr logs, `energy`, HDF5 diagnostics, and
+  restart snapshots. Use adapter-required output metadata for exact project
+  checks.
+- For namelist meaning, numerical stability, physical interpretation, emout
+  APIs, and plotting details, prefer `MPIEMSES3D Context`, `emout Context`,
+  enabled knowledge imports, project materials, or upstream documentation.
+
+Do not treat this file as a full MPIEMSES3D manual. It is only the runops-side
+handoff point when richer simulator context has not been installed or mounted.

--- a/src/runops/templates/harness/shared/partials/agent-body.md.j2
+++ b/src/runops/templates/harness/shared/partials/agent-body.md.j2
@@ -14,7 +14,7 @@ campaign 設計、case / survey 編集、run 生成、投入、監視、解析�
 0. **runops CLI は uvx で呼ぶ** — 例: `uvx --from runops runo context --json`
    `.venv/` は必要な runtime tool を直接実行するときだけ activate する。
 1. `uvx --from runops runo context --json` で project の現在地を把握する
-2. 必要なら `uvx --from runops runo lint --scope structure,analysis,knowledge` で読み入口と成果物索引を確認する
+2. 必要なら `uvx --from runops runo lint --scope structure,analysis,knowledge,plugins` で読み入口、成果物索引、推奨 plugin metadata を確認する
 3. `campaign.toml` を読む
 4. `research/agenda.md` があれば読む
 5. 関連する `cases/**/case.toml` と `runs/**/survey.toml` を読む
@@ -171,11 +171,16 @@ lab notebook の entry が積み上がってストーリーになったら、
 
 ## 推奨 Codex plugins
 
-この project の simulator / site 選択に基づく推奨 plugin。runops は project state を
+この project / simulator / site 選択に基づく推奨 plugin。runops は project state を
 作るだけで、plugin の install / enable はユーザーの Codex 環境で行う。
+作業を始める前に `uvx --from runops runo plugins --check` で推薦 metadata を確認する。
+この check は install 済み状態ではなく、project が持つ推薦情報だけを検査する。
 
 {% for plugin in codex_plugin_recommendations -%}
 - **{{ plugin.display_name }}** (`{{ plugin.name }}`{% if plugin.visibility != "public" %}, {{ plugin.visibility }}{% endif %}) — {{ plugin.reason }}
+{% if plugin.capabilities %}
+  委譲役割: {{ plugin.capabilities | join(", ") }}
+{% endif %}
 
   導入:
   ```bash

--- a/src/runops/templates/skills/runops-reference/SKILL.md
+++ b/src/runops/templates/skills/runops-reference/SKILL.md
@@ -17,7 +17,7 @@ project 側で実行するときの標準形は `uvx --from runops runo <command
 ```bash
 runo context --json      # project / campaign / runs / failures の概要
 runo lint                # project state の health check
-runo lint --scope structure,analysis,knowledge
+runo lint --scope structure,analysis,knowledge,plugins
 runo runs list           # run 一覧
 runo runs list runs/a runs/b  # 複数 PATH 指定
 runo runs jobs           # submitted/running のジョブ一覧
@@ -231,7 +231,7 @@ fragment は `[merge]` と `[compatibility]` を確認してから使う。
 
 ```bash
 runo doctor             # 環境検査
-runo lint               # project state / Agent context の health check
+runo lint               # project state / Agent context / plugin metadata の health check
 runo update-refs        # opt-in refs mirror の更新 + ナレッジ再生成
 runo config show        # 設定表示
 ```

--- a/src/runops/templates/skills/setup-campaign/SKILL.md
+++ b/src/runops/templates/skills/setup-campaign/SKILL.md
@@ -18,8 +18,9 @@ description: Set up campaign.toml from a research theme description. Use after r
 # プロジェクトの現状を把握
 uvx --from runops runo context --no-json
 
-# シミュレータ固有のガイド（パラメータ名・物理的意味）
-cat CLAUDE.md   # agent_guide セクションにシミュレータ知識がある
+# 推奨 plugin と委譲 role を確認
+uvx --from runops runo plugins --check
+uvx --from runops runo plugins --json
 
 # campaign.toml のスキーマ
 uvx --from runops runo context --json
@@ -105,6 +106,9 @@ EOF
 ## 注意
 
 - 既存の `campaign.toml` の `name` と `simulator` は上書きしない（ユーザーが明示的に変更を指示した場合を除く）
-- シミュレータの agent_guide に記載されたパラメータ名を優先的に使う
+- パラメータ名・物理的意味・観測量の設計は simulator/environment plugin、
+  `.runops/knowledge/enabled/imports.md`、project materials を優先する
+- adapter の agent guide は runops 側の最小 fallback であり、完全な simulator manual
+  として扱わない
 - 物理単位は必ず `unit` に記入する
 - `reason` は将来の自分や共同研究者が読んで意図がわかるように書く

--- a/src/runops/templates/skills/setup-runops/SKILL.md
+++ b/src/runops/templates/skills/setup-runops/SKILL.md
@@ -56,6 +56,7 @@ project root にいるか、または親 directory に `runops.toml` がある�
 ```bash
 uvx --from runops runo context --no-json
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 `runops.toml` が見つからない場合は、まず cwd が project root から外れていないか確認する。
@@ -100,7 +101,8 @@ submit はまだしない。
 この場合:
 
 1. `uvx --from runops runo context --no-json` と
-   `uvx --from runops runo doctor` で project の現在状態を読む
+   `uvx --from runops runo doctor`、`uvx --from runops runo plugins --check`
+   で project の現在状態を読む
 2. simulator / site / launcher の不足があれば修復方針を出す
 3. `{{ skill_prefix }}setup-campaign` / `{{ skill_prefix }}new-case` /
    `{{ skill_prefix }}survey-design` を必要に応じて使う
@@ -194,7 +196,7 @@ project で `runo notes append` が使えるなら、準備段階の判断を
 
 ## 完了条件
 
-- `runo doctor` の結果を確認した
+- `runo doctor` と `runo plugins --check` の結果を確認した
 - project root と次に編集すべきファイルが明確
 - campaign / case / survey / run 生成のどこまで進めたかを説明した
 - init / setup 生成物の baseline commit が必要かどうかを案内した

--- a/tests/test_adapters/test_contract.py
+++ b/tests/test_adapters/test_contract.py
@@ -16,6 +16,11 @@ from runops.adapters import (
     list_adapters,
 )
 from runops.adapters.base import SimulatorAdapter
+from runops.core.codex_plugin import CodexPluginRecommendation
+from runops.core.plugins import (
+    detect_codex_plugin_conflicts,
+    validate_codex_plugin_recommendation,
+)
 from tests.factories import write_toml
 
 
@@ -125,6 +130,63 @@ def test_contract_metadata_methods_return_expected_types(
     assert isinstance(spec.adapter_cls.codex_plugins(), list)
     assert isinstance(spec.adapter_cls.case_template(), dict)
     assert isinstance(spec.adapter_cls.agent_guide(), str)
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "expected_plugins", "forbidden_phrases"),
+    [
+        (
+            BeachAdapter,
+            ("BEACH Context", "beach-context"),
+            (
+                "パラメータサーベイでよく変えるパラメータ",
+                "environment.electron_density",
+            ),
+        ),
+        (
+            EmseAdapter,
+            ("MPIEMSES3D Context", "emout Context", "delegated_capabilities"),
+            ("主要な namelist", "species[0].temperature"),
+        ),
+    ],
+    ids=["beach", "emses"],
+)
+def test_builtin_agent_guides_are_plugin_first_fallbacks(
+    adapter_cls: type[SimulatorAdapter],
+    expected_plugins: tuple[str, ...],
+    forbidden_phrases: tuple[str, ...],
+) -> None:
+    """Bundled agent guides should not become long simulator manuals again."""
+    guide = adapter_cls.agent_guide()
+
+    for expected in expected_plugins:
+        assert expected in guide
+    for phrase in forbidden_phrases:
+        assert phrase not in guide
+
+
+@pytest.mark.parametrize(
+    "spec",
+    ADAPTER_CONTRACT_SPECS,
+    ids=lambda spec: spec.name,
+)
+def test_contract_codex_plugin_recommendations_are_complete(
+    spec: AdapterContractSpec,
+) -> None:
+    """Adapter plugin recommendations must be usable without project context."""
+    recommendations = spec.adapter_cls.codex_plugins()
+
+    assert all(
+        isinstance(recommendation, CodexPluginRecommendation)
+        for recommendation in recommendations
+    )
+    issues = [
+        issue
+        for recommendation in recommendations
+        for issue in validate_codex_plugin_recommendation(recommendation)
+    ]
+    issues.extend(detect_codex_plugin_conflicts(recommendations))
+    assert [issue.to_dict() for issue in issues] == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -417,6 +417,7 @@ class TestInit:
         assert "Recommended Codex plugins" in result.output
         assert "MPIEMSES3D Context" in result.output
         assert "emout Context" in result.output
+        assert "Capabilities: input-review, parameter-design" in result.output
         content = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
         # Simulator details are via imports.md, not inline
         assert "シミュレータ固有知識" not in content
@@ -747,6 +748,10 @@ class TestInit:
         site_md = tmp_path / "SITE.md"
         assert site_md.exists()
         assert "Camphor3" in site_md.read_text(encoding="utf-8")
+        site_toml = (tmp_path / "site.toml").read_text(encoding="utf-8")
+        assert "#:schema" in site_toml
+        assert "/schemas/site.json" in site_toml
+        assert "[site.codex_plugins.kudpc-hpc-codex-plugin]" in site_toml
         assert "KUDPC HPC" in result.output
         assert "KUDPC HPC" in (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
 
@@ -969,3 +974,51 @@ class TestDoctor:
 
         assert result.exit_code == 1
         assert "check(s) failed" in result.output
+
+    def test_doctor_fails_on_incomplete_codex_plugin_metadata(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Doctor treats incomplete project-side plugin metadata as a failure."""
+        (tmp_path / "runops.toml").write_text('[project]\nname = "test-project"\n')
+        (tmp_path / "simulators.toml").write_text("[simulators]\n")
+        (tmp_path / "launchers.toml").write_text("[launchers]\n")
+        (tmp_path / "site.toml").write_text(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.incomplete]\n"
+            'display_name = "Incomplete Plugin"\n',
+            encoding="utf-8",
+        )
+
+        with patch("runops.cli.init.shutil.which", return_value="/usr/bin/sbatch"):
+            result = runner.invoke(app, ["doctor", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "[FAIL] Codex plugin recommendation metadata" in result.output
+        assert "incomplete.reason" in result.output
+        assert "incomplete.install_hint" in result.output
+
+    def test_doctor_warns_on_codex_plugin_metadata_warnings(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Doctor surfaces warning-only plugin metadata without failing."""
+        (tmp_path / "runops.toml").write_text('[project]\nname = "test-project"\n')
+        (tmp_path / "simulators.toml").write_text("[simulators]\n")
+        (tmp_path / "launchers.toml").write_text("[launchers]\n")
+        (tmp_path / "site.toml").write_text(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+            'visibility = "private"\n',
+            encoding="utf-8",
+        )
+
+        with patch("runops.cli.init.shutil.which", return_value="/usr/bin/sbatch"):
+            result = runner.invoke(app, ["doctor", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "[WARN] Codex plugin recommendation metadata" in result.output
+        assert "site-context.visibility" in result.output

--- a/tests/test_cli/test_init_helpers.py
+++ b/tests/test_cli/test_init_helpers.py
@@ -145,6 +145,7 @@ def test_load_site_profiles_reads_bundled_site_files() -> None:
     assert profiles["camphor"].source_path.name == "camphor.toml"
     assert profiles["camphor"].codex_plugins
     assert profiles["camphor"].codex_plugins[0].name == "kudpc-hpc-codex-plugin"
+    assert "slurm-jobs" in profiles["camphor"].codex_plugins[0].capabilities
 
 
 def test_prompt_launchers_supports_site_and_manual_launchers(

--- a/tests/test_cli/test_lint.py
+++ b/tests/test_cli/test_lint.py
@@ -91,3 +91,20 @@ def test_lint_cli_rejects_unknown_scope(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "Unknown lint scope" in result.output
+
+
+def test_lint_cli_reports_plugin_metadata_errors(tmp_path: Path) -> None:
+    """The plugins scope exposes Codex plugin recommendation metadata errors."""
+    _write_project(tmp_path)
+    (tmp_path / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.incomplete]\n"
+        'display_name = "Incomplete Plugin"\n',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["lint", str(tmp_path), "--scope", "plugins"])
+
+    assert result.exit_code == 1
+    assert "plugins.metadata_error" in result.output
+    assert "incomplete.reason" in result.output

--- a/tests/test_cli/test_plugins.py
+++ b/tests/test_cli/test_plugins.py
@@ -1,0 +1,362 @@
+"""Tests for the ``runo plugins`` command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from runops.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_project(project_dir: Path) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        '[project]\nname = "plugin-demo"\ndescription = ""\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        "[simulators.emses]\n"
+        'adapter = "emses"\n'
+        'resolver_mode = "package"\n'
+        'executable = "mpiemses3D"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_project_with_site_plugin(
+    project_dir: Path,
+    *,
+    site_plugin: str,
+) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        '[project]\nname = "plugin-demo"\ndescription = ""\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        "[simulators]\n",
+        encoding="utf-8",
+    )
+    project_dir.joinpath("site.toml").write_text(
+        '[site]\nname = "test-site"\n' + site_plugin,
+        encoding="utf-8",
+    )
+
+
+def _write_project_with_missing_adapter(project_dir: Path) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        '[project]\nname = "plugin-demo"\ndescription = ""\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        "[simulators.production]\n"
+        'adapter = "missing_external"\n'
+        'resolver_mode = "package"\n'
+        'executable = "missing-solver"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_project_with_simulator_plugin(project_dir: Path) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        '[project]\nname = "plugin-demo"\ndescription = ""\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        "[simulators.production]\n"
+        'adapter = "generic"\n'
+        'resolver_mode = "package"\n'
+        'executable = "solver"\n'
+        "\n[simulators.production.codex_plugins.production-context]\n"
+        'display_name = "Production Context"\n'
+        'reason = "Project-specific production workflow guidance."\n'
+        'install_hint = "codex plugin add production-context@project"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_beach_project(project_dir: Path) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        '[project]\nname = "beach-demo"\ndescription = ""\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        "[simulators.beach]\n"
+        'adapter = "beach"\n'
+        'resolver_mode = "package"\n'
+        'executable = "beach"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_project_with_project_plugin(project_dir: Path) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        '[project]\nname = "plugin-demo"\ndescription = ""\n'
+        "\n[project.codex_plugins.analysis-context]\n"
+        'display_name = "Analysis Context"\n'
+        'reason = "Team analysis workflow guidance."\n'
+        'install_hint = "codex plugin add analysis-context@project"\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        "[simulators]\n",
+        encoding="utf-8",
+    )
+
+
+def test_plugins_outputs_recommendations(tmp_path: Path) -> None:
+    """The command lists project Codex plugin recommendations."""
+    _write_project(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Codex plugin recommendations for plugin-demo" in result.output
+    assert "runops does not install or enable these plugins" in result.output
+    assert "MPIEMSES3D Context" in result.output
+    assert "emout Context" in result.output
+    assert "Delegated capabilities:" in result.output
+    assert "parameter-design: mpiemses3d-context" in result.output
+    assert "Capabilities: input-review, parameter-design" in result.output
+
+
+def test_plugins_outputs_json(tmp_path: Path) -> None:
+    """The command emits machine-readable inventory JSON."""
+    _write_project(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["$schema"] == "schemas/codex-plugin-inventory.json"
+    assert data["schema_version"] == 1
+    assert data["project"]["name"] == "plugin-demo"
+    assert data["simulators"] == ["emses"]
+    assert data["management"]["runops_installs_plugins"] is False
+    assert data["management"]["runops_enables_plugins"] is False
+    assert data["management"]["runops_inspects_user_install_state"] is False
+    assert [plugin["name"] for plugin in data["recommendations"]] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    assert data["recommendations"][0]["sources"] == ["simulator:emses"]
+    assert "parameter-design" in data["recommendations"][0]["capabilities"]
+    assert "visualization-script" in data["recommendations"][1]["capabilities"]
+    assert data["delegated_capabilities"]["parameter-design"] == ["mpiemses3d-context"]
+    assert data["delegated_capabilities"]["visualization-script"] == ["emout-context"]
+
+
+def test_plugins_outputs_simulator_config_recommendations_json(
+    tmp_path: Path,
+) -> None:
+    """Project simulator config recommendations are visible to external tools."""
+    _write_project_with_simulator_plugin(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["$schema"] == "schemas/codex-plugin-inventory.json"
+    assert [plugin["name"] for plugin in data["recommendations"]] == [
+        "production-context"
+    ]
+    assert data["recommendations"][0]["source"] == "simulator:production"
+    assert data["recommendations"][0]["sources"] == ["simulator:production"]
+
+
+def test_plugins_outputs_project_config_recommendations_json(
+    tmp_path: Path,
+) -> None:
+    """Project-wide recommendations are visible to external tools."""
+    _write_project_with_project_plugin(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["$schema"] == "schemas/codex-plugin-inventory.json"
+    assert [plugin["name"] for plugin in data["recommendations"]] == [
+        "analysis-context"
+    ]
+    assert data["recommendations"][0]["source"] == "project:plugin-demo"
+    assert data["recommendations"][0]["sources"] == ["project:plugin-demo"]
+
+
+def test_plugins_outputs_beach_adapter_recommendation_json(tmp_path: Path) -> None:
+    """BEACH adapter recommendations are visible to external tools."""
+    _write_beach_project(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["$schema"] == "schemas/codex-plugin-inventory.json"
+    assert [plugin["name"] for plugin in data["recommendations"]] == ["beach-context"]
+    assert data["recommendations"][0]["display_name"] == "BEACH Context"
+    assert data["recommendations"][0]["source"] == "simulator:beach"
+    assert data["recommendations"][0]["sources"] == ["simulator:beach"]
+    assert "config-review" in data["recommendations"][0]["capabilities"]
+    assert "cookbook" in data["recommendations"][0]["capabilities"]
+    assert data["delegated_capabilities"]["cookbook"] == ["beach-context"]
+    assert data["delegated_capabilities"]["config-review"] == ["beach-context"]
+
+
+def test_plugins_check_passes_for_complete_recommendations(tmp_path: Path) -> None:
+    """--check validates advisory metadata without checking install state."""
+    _write_project(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--check"])
+
+    assert result.exit_code == 0
+    assert "Plugin recommendation metadata: OK" in result.output
+
+
+def test_plugins_check_reports_incomplete_recommendations(tmp_path: Path) -> None:
+    """--check fails on incomplete recommendation metadata."""
+    _write_project_with_site_plugin(
+        tmp_path,
+        site_plugin=(
+            '[site.codex_plugins.incomplete]\ndisplay_name = "Incomplete Plugin"\n'
+        ),
+    )
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--check"])
+
+    assert result.exit_code == 1
+    assert "2 error(s), 0 warning(s)" in result.output
+    assert "[error] incomplete.reason" in result.output
+    assert "[error] incomplete.install_hint" in result.output
+
+
+def test_plugins_check_strict_fails_on_warnings(tmp_path: Path) -> None:
+    """--strict makes warning-only metadata checks fail."""
+    _write_project_with_site_plugin(
+        tmp_path,
+        site_plugin=(
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+            'visibility = "private"\n'
+        ),
+    )
+
+    relaxed = runner.invoke(app, ["plugins", str(tmp_path), "--check"])
+    strict = runner.invoke(app, ["plugins", str(tmp_path), "--check", "--strict"])
+
+    assert relaxed.exit_code == 0
+    assert "0 error(s), 1 warning(s)" in relaxed.output
+    assert strict.exit_code == 1
+    assert "0 error(s), 1 warning(s)" in strict.output
+
+
+def test_plugins_check_reports_malformed_site_recommendations(tmp_path: Path) -> None:
+    """Malformed site plugin metadata is surfaced as a warning."""
+    _write_project_with_site_plugin(
+        tmp_path,
+        site_plugin='codex_plugins = ["broken"]\n',
+    )
+
+    relaxed = runner.invoke(app, ["plugins", str(tmp_path), "--check"])
+    strict = runner.invoke(app, ["plugins", str(tmp_path), "--check", "--strict"])
+
+    assert relaxed.exit_code == 0
+    assert "0 error(s), 1 warning(s)" in relaxed.output
+    assert "[warning] test-site.codex_plugins" in relaxed.output
+    assert "Site-level Codex plugin recommendations" in relaxed.output
+    assert strict.exit_code == 1
+
+
+def test_plugins_check_reports_malformed_capabilities(tmp_path: Path) -> None:
+    """Malformed capability metadata is visible in relaxed and strict checks."""
+    _write_project_with_site_plugin(
+        tmp_path,
+        site_plugin=(
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+            'capabilities = { role = "broken" }\n'
+        ),
+    )
+
+    relaxed = runner.invoke(app, ["plugins", str(tmp_path), "--check"])
+    strict = runner.invoke(app, ["plugins", str(tmp_path), "--check", "--strict"])
+
+    assert relaxed.exit_code == 0
+    assert "0 error(s), 1 warning(s)" in relaxed.output
+    assert "[warning] site-context.capabilities" in relaxed.output
+    assert "non-empty strings" in relaxed.output
+    assert strict.exit_code == 1
+
+
+def test_plugins_check_warns_when_adapter_is_not_registered(tmp_path: Path) -> None:
+    """Missing external adapters are reported without checking install state."""
+    _write_project_with_missing_adapter(tmp_path)
+
+    relaxed = runner.invoke(app, ["plugins", str(tmp_path), "--check"])
+    strict = runner.invoke(app, ["plugins", str(tmp_path), "--check", "--strict"])
+
+    assert relaxed.exit_code == 0
+    assert "0 error(s), 1 warning(s)" in relaxed.output
+    assert "[warning] missing_external.adapter" in relaxed.output
+    assert "could not be collected" in relaxed.output
+    assert strict.exit_code == 1
+    assert "0 error(s), 1 warning(s)" in strict.output
+
+
+def test_plugins_check_outputs_json(tmp_path: Path) -> None:
+    """--check --json emits inventory plus check issues."""
+    _write_project(tmp_path)
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--check", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["$schema"] == "schemas/codex-plugin-check-result.json"
+    assert data["schema_version"] == 1
+    assert data["ok"] is True
+    assert data["strict_ok"] is True
+    assert data["summary"]["recommendations"] == 2
+    assert data["issues"] == []
+    assert data["inventory"]["$schema"] == "schemas/codex-plugin-inventory.json"
+    assert data["inventory"]["management"]["runops_installs_plugins"] is False
+
+
+def test_plugins_check_json_includes_strict_status_for_warnings(
+    tmp_path: Path,
+) -> None:
+    """--check --json exposes strict warning status from the core payload."""
+    _write_project_with_site_plugin(
+        tmp_path,
+        site_plugin=(
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+            'visibility = "private"\n'
+        ),
+    )
+
+    result = runner.invoke(app, ["plugins", str(tmp_path), "--check", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["$schema"] == "schemas/codex-plugin-check-result.json"
+    assert data["ok"] is True
+    assert data["strict_ok"] is False
+    assert data["summary"] == {
+        "recommendations": 1,
+        "errors": 0,
+        "warnings": 1,
+    }
+
+
+def test_plugins_fails_outside_project(tmp_path: Path) -> None:
+    """Missing runops.toml produces a user-facing error."""
+    result = runner.invoke(app, ["plugins", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Error: No runops.toml found" in result.output

--- a/tests/test_cli/test_setup.py
+++ b/tests/test_cli/test_setup.py
@@ -152,6 +152,37 @@ def test_setup_runs_auth_for_simulator_packages_without_refs(
     assert "Recommended Codex plugins" in result.output
     assert "MPIEMSES3D Context" in result.output
     assert "emout Context" in result.output
+    assert "Capabilities: input-review, parameter-design" in result.output
+
+
+def test_setup_outputs_project_config_plugin_recommendations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setup shows project-wide plugin recommendations from runops.toml."""
+    project_dir = tmp_path / "setup-project"
+    _make_existing_project(project_dir)
+    (project_dir / "runops.toml").write_text(
+        '[project]\nname = "setup-project"\n'
+        "\n[project.codex_plugins.analysis-context]\n"
+        'display_name = "Analysis Context"\n'
+        'reason = "Team analysis workflow guidance."\n'
+        'install_hint = "codex plugin add analysis-context@project"\n'
+        'capabilities = ["analysis-workflow", "handoff"]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "runops.cli.init._bootstrap_environment",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(app, ["setup", "--path", str(project_dir)])
+
+    assert result.exit_code == 0
+    assert "Analysis Context" in result.output
+    assert "`analysis-context`" in result.output
+    assert "Capabilities: analysis-workflow, handoff" in result.output
 
 
 def test_setup_with_refs_clones_reference_mirrors(

--- a/tests/test_cli/test_update_harness.py
+++ b/tests/test_cli/test_update_harness.py
@@ -125,6 +125,41 @@ class TestUpdateHarnessBasic:
         assert result.exit_code == 0
         assert "HarnessOps skipped (disabled)" in result.output
 
+    def test_update_harness_includes_project_config_plugin_recommendations(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Generated agent docs include project-wide Codex plugin recommendations."""
+        _init_project(tmp_path)
+        (tmp_path / "runops.toml").write_text(
+            '[project]\nname = "plugin-project"\n'
+            "\n[project.codex_plugins.analysis-context]\n"
+            'display_name = "Analysis Context"\n'
+            'reason = "Team analysis workflow guidance."\n'
+            'install_hint = "codex plugin add analysis-context@project"\n'
+            'capabilities = ["analysis-workflow", "handoff"]\n'
+            "\n[harness]\nupstream_feedback = true\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "update-harness",
+                str(tmp_path),
+                "--skip-pull",
+                "--force",
+                "--only",
+                "AGENTS.md",
+            ],
+        )
+
+        assert result.exit_code == 0
+        agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+        assert "Analysis Context" in agents
+        assert "`analysis-context`" in agents
+        assert "委譲役割: analysis-workflow, handoff" in agents
+
     def test_creates_harness_lock(self, tmp_path: Path) -> None:
         """init creates .runops/harness.lock with template hashes."""
         _init_project(tmp_path)

--- a/tests/test_core/test_context.py
+++ b/tests/test_core/test_context.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import tomli_w
 
 from runops.core.context import (
+    _collect_codex_plugins,
     _collect_facts_summary,
     _collect_knowledge_paths,
     _collect_notes_summary,
@@ -149,6 +150,177 @@ def test_context_includes_knowledge_integration_details(tmp_path: Path) -> None:
         "name",
         "content",
     ]
+
+
+def test_context_includes_codex_plugin_recommendations(tmp_path: Path) -> None:
+    """Agent context includes advisory external Codex plugin inventory."""
+    _write_toml(
+        tmp_path / "runops.toml",
+        {
+            "project": {
+                "name": "plugin-context",
+                "codex_plugins": {
+                    "analysis-context": {
+                        "display_name": "Analysis Context",
+                        "reason": "Team analysis workflow guidance.",
+                        "install_hint": "codex plugin add analysis-context@project",
+                    }
+                },
+            },
+        },
+    )
+    _write_toml(
+        tmp_path / "simulators.toml",
+        {
+            "simulators": {
+                "production": {
+                    "adapter": "emses",
+                    "resolver_mode": "package",
+                    "executable": "mpiemses3D",
+                }
+            }
+        },
+    )
+    _write_toml(
+        tmp_path / "site.toml",
+        {
+            "site": {
+                "name": "test-site",
+                "codex_plugins": {
+                    "site-context": {
+                        "display_name": "Site Context",
+                        "reason": "Site-local workflow guidance.",
+                        "install_hint": "codex plugin add site-context@test",
+                    }
+                },
+            }
+        },
+    )
+
+    ctx = build_project_context(tmp_path)
+
+    plugins = ctx["codex_plugins"]
+    assert plugins["schema_version"] == 1
+    assert plugins["inventory_schema"] == "schemas/codex-plugin-inventory.json"
+    assert plugins["check_result_schema"] == "schemas/codex-plugin-check-result.json"
+    assert plugins["ok"] is True
+    assert plugins["strict_ok"] is True
+    assert plugins["summary"] == {
+        "recommendations": 4,
+        "errors": 0,
+        "warnings": 0,
+    }
+    assert plugins["management"]["runops_installs_plugins"] is False
+    assert plugins["simulators"] == ["production"]
+    assert plugins["site"] == "test-site"
+    assert [plugin["name"] for plugin in plugins["recommendations"]] == [
+        "mpiemses3d-context",
+        "emout-context",
+        "analysis-context",
+        "site-context",
+    ]
+    assert plugins["recommendations"][0]["sources"] == [
+        "simulator:emses",
+        "simulator:production",
+    ]
+    assert "parameter-design" in plugins["recommendations"][0]["capabilities"]
+    assert plugins["delegated_capabilities"]["parameter-design"] == [
+        "mpiemses3d-context"
+    ]
+    assert plugins["delegated_capabilities"]["output-analysis"] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    assert plugins["collection_issues"] == []
+    assert plugins["issues"] == []
+    assert ctx["section_status"]["codex_plugins"] == "ok"
+
+
+def test_context_surfaces_codex_plugin_metadata_warnings(tmp_path: Path) -> None:
+    """Agent context keeps plugin collection warnings visible."""
+    _write_toml(tmp_path / "runops.toml", {"project": {"name": "plugin-context"}})
+    (tmp_path / "site.toml").write_text(
+        '[site]\nname = "test-site"\ncodex_plugins = ["broken"]\n',
+        encoding="utf-8",
+    )
+
+    ctx = build_project_context(tmp_path)
+
+    plugins = ctx["codex_plugins"]
+    assert ctx["status"] == "degraded"
+    assert ctx["section_status"]["codex_plugins"] == "warning"
+    assert plugins["ok"] is True
+    assert plugins["strict_ok"] is False
+    assert plugins["summary"] == {
+        "recommendations": 0,
+        "errors": 0,
+        "warnings": 1,
+    }
+    assert plugins["collection_issues"][0]["source"] == "site:test-site"
+    assert plugins["issues"][0]["field"] == "codex_plugins"
+    assert any(
+        "runo plugins --check" in diagnostic["message"]
+        for diagnostic in ctx["diagnostics"]
+        if diagnostic["section"] == "codex_plugins"
+    )
+
+
+def test_context_surfaces_codex_plugin_metadata_errors(tmp_path: Path) -> None:
+    """Agent context marks incomplete plugin metadata as an error."""
+    _write_toml(tmp_path / "runops.toml", {"project": {"name": "plugin-context"}})
+    (tmp_path / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.incomplete]\n"
+        'display_name = "Incomplete Plugin"\n',
+        encoding="utf-8",
+    )
+
+    ctx = build_project_context(tmp_path)
+
+    plugins = ctx["codex_plugins"]
+    assert ctx["status"] == "degraded"
+    assert ctx["section_status"]["codex_plugins"] == "error"
+    assert plugins["ok"] is False
+    assert plugins["strict_ok"] is False
+    assert plugins["summary"] == {
+        "recommendations": 1,
+        "errors": 2,
+        "warnings": 0,
+    }
+    assert [issue["field"] for issue in plugins["issues"]] == [
+        "reason",
+        "install_hint",
+    ]
+
+
+def test_collect_codex_plugins_reports_warning_on_broken_project(
+    tmp_path: Path,
+) -> None:
+    """Broken project config degrades context instead of hiding other sections."""
+    diagnostics: list[dict[str, str]] = []
+    section_status: dict[str, str] = {}
+
+    plugins = _collect_codex_plugins(tmp_path, diagnostics, section_status)
+
+    assert plugins["schema_version"] == 1
+    assert plugins["inventory_schema"] == "schemas/codex-plugin-inventory.json"
+    assert plugins["check_result_schema"] == "schemas/codex-plugin-check-result.json"
+    assert plugins["ok"] is False
+    assert plugins["strict_ok"] is False
+    assert plugins["summary"] == {
+        "recommendations": 0,
+        "errors": 0,
+        "warnings": 1,
+    }
+    assert plugins["simulators"] == []
+    assert plugins["site"] == ""
+    assert plugins["management"]["runops_installs_plugins"] is False
+    assert plugins["recommendations"] == []
+    assert plugins["delegated_capabilities"] == {}
+    assert plugins["collection_issues"] == []
+    assert plugins["issues"] == []
+    assert section_status["codex_plugins"] == "warning"
+    assert diagnostics[0]["section"] == "codex_plugins"
 
 
 def test_context_includes_research_agenda_and_latest_note(tmp_path: Path) -> None:

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -186,3 +186,70 @@ def test_project_lint_reports_agenda_without_evidence_path(tmp_path: Path) -> No
         issue.issue_id == "knowledge.next_actions_evidence_missing"
         for issue in report.issues
     )
+
+
+def test_project_lint_reports_incomplete_codex_plugin_metadata(
+    tmp_path: Path,
+) -> None:
+    """Plugin recommendation metadata errors are project health errors."""
+    _write_project(tmp_path)
+    (tmp_path / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.incomplete]\n"
+        'display_name = "Incomplete Plugin"\n',
+        encoding="utf-8",
+    )
+
+    report = run_project_lint(tmp_path, scopes=("plugins",))
+
+    assert report.status == "fail"
+    assert report.error_count == 2
+    assert [issue.issue_id for issue in report.issues] == [
+        "plugins.metadata_error",
+        "plugins.metadata_error",
+    ]
+    assert all(issue.path == tmp_path / "site.toml" for issue in report.issues)
+
+
+def test_project_lint_reports_codex_plugin_metadata_warnings(
+    tmp_path: Path,
+) -> None:
+    """Plugin recommendation metadata warnings remain non-fatal by default."""
+    _write_project(tmp_path)
+    (tmp_path / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.site-context]\n"
+        'display_name = "Site Context"\n'
+        'reason = "Site-local workflow guidance."\n'
+        'install_hint = "codex plugin add site-context@test"\n'
+        'visibility = "private"\n',
+        encoding="utf-8",
+    )
+
+    report = run_project_lint(tmp_path, scopes=("plugins",))
+
+    assert report.status == "warning"
+    assert report.error_count == 0
+    assert report.warning_count == 1
+    issue = report.issues[0]
+    assert issue.issue_id == "plugins.metadata_warning"
+    assert issue.path == tmp_path / "site.toml"
+
+
+def test_project_lint_points_project_plugin_issues_to_runops_toml(
+    tmp_path: Path,
+) -> None:
+    """Project-level plugin metadata issues point users back to runops.toml."""
+    _write_project(tmp_path)
+    (tmp_path / "runops.toml").write_text(
+        '[project]\nname = "demo"\ncodex_plugins = ["broken"]\n',
+        encoding="utf-8",
+    )
+
+    report = run_project_lint(tmp_path, scopes=("plugins",))
+
+    assert report.status == "warning"
+    assert report.warning_count == 1
+    issue = report.issues[0]
+    assert issue.issue_id == "plugins.metadata_warning"
+    assert issue.path == tmp_path / "runops.toml"

--- a/tests/test_core/test_plugins.py
+++ b/tests/test_core/test_plugins.py
@@ -1,0 +1,724 @@
+"""Tests for Codex plugin recommendation inventory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from runops.core.codex_plugin import (
+    CODEX_PLUGIN_ACTIVATION_SCOPE,
+    CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION,
+    CodexPluginRecommendation,
+    codex_plugin_management_policy,
+)
+from runops.core.plugins import (
+    adapter_lookup_entries,
+    adapter_lookup_names,
+    check_codex_plugin_inventory,
+    delegated_codex_plugin_capabilities,
+    load_project_codex_plugin_inventory,
+)
+
+
+def _write_project(
+    project_dir: Path,
+    *,
+    simulators_toml: str,
+    project_toml: str | None = None,
+    site_toml: str | None = None,
+) -> None:
+    project_dir.joinpath("runops.toml").write_text(
+        project_toml or '[project]\nname = "plugin-demo"\ndescription = ""\n',
+        encoding="utf-8",
+    )
+    project_dir.joinpath("simulators.toml").write_text(
+        simulators_toml,
+        encoding="utf-8",
+    )
+    if site_toml is not None:
+        project_dir.joinpath("site.toml").write_text(site_toml, encoding="utf-8")
+
+
+def test_adapter_lookup_names_prefers_configured_adapter() -> None:
+    """Simulator aliases resolve to their configured adapter registry key."""
+    names = adapter_lookup_names(
+        ["production"],
+        {"production": {"adapter": "emses"}},
+    )
+
+    assert names == ["emses"]
+
+
+def test_adapter_lookup_entries_keep_simulator_and_adapter_names() -> None:
+    """Lookup entries preserve the project name while resolving adapter aliases."""
+    entries = adapter_lookup_entries(
+        ["production", "baseline"],
+        {
+            "production": {"adapter": "emses"},
+            "baseline": {"adapter": "emses"},
+        },
+    )
+
+    assert entries == [("production", "emses")]
+
+
+def test_codex_plugin_recommendation_serializes_common_payloads() -> None:
+    """Recommendation serialization stays centralized for JSON and site TOML."""
+    plugin = CodexPluginRecommendation(
+        name="site-context",
+        display_name="Site Context",
+        reason="Site-local workflow guidance.",
+        install_hint="codex plugin add site-context@test",
+        activation_hint="Start a new Codex thread.",
+        visibility="private-or-gated",
+        source="site:test-site",
+        capabilities=("host-role-routing", "slurm-jobs"),
+    )
+
+    assert plugin.to_dict() == {
+        "name": "site-context",
+        "display_name": "Site Context",
+        "reason": "Site-local workflow guidance.",
+        "install_hint": "codex plugin add site-context@test",
+        "activation_hint": "Start a new Codex thread.",
+        "visibility": "private-or-gated",
+        "source": "site:test-site",
+        "sources": ["site:test-site"],
+        "capabilities": ["host-role-routing", "slurm-jobs"],
+    }
+    assert plugin.to_site_mapping() == {
+        "display_name": "Site Context",
+        "visibility": "private-or-gated",
+        "reason": "Site-local workflow guidance.",
+        "install_hint": "codex plugin add site-context@test",
+        "activation_hint": "Start a new Codex thread.",
+        "capabilities": ["host-role-routing", "slurm-jobs"],
+    }
+
+    with_project_source = plugin.with_additional_source("simulator:production")
+    assert with_project_source.source == "site:test-site, simulator:production"
+    assert with_project_source.to_dict()["sources"] == [
+        "site:test-site",
+        "simulator:production",
+    ]
+
+
+def test_codex_plugin_management_policy_is_user_local() -> None:
+    policy = codex_plugin_management_policy()
+
+    assert policy == {
+        "runops_installs_plugins": False,
+        "runops_enables_plugins": False,
+        "runops_inspects_user_install_state": False,
+        "activation_scope": CODEX_PLUGIN_ACTIVATION_SCOPE,
+    }
+
+
+def test_delegated_capability_index_maps_roles_to_plugins() -> None:
+    """Capability index lets tools find delegated plugin roles without parsing prose."""
+    index = delegated_codex_plugin_capabilities(
+        [
+            CodexPluginRecommendation(
+                name="site-context",
+                display_name="Site Context",
+                reason="Site-local workflow guidance.",
+                install_hint="codex plugin add site-context@test",
+                source="site:test",
+                capabilities=("slurm-jobs", "host-role-routing", "slurm-jobs"),
+            ),
+            CodexPluginRecommendation(
+                name="analysis-context",
+                display_name="Analysis Context",
+                reason="Analysis workflow guidance.",
+                install_hint="codex plugin add analysis-context@test",
+                source="project:test",
+                capabilities=("analysis-workflow", "slurm-jobs"),
+            ),
+        ]
+    )
+
+    assert index == {
+        "analysis-workflow": ["analysis-context"],
+        "host-role-routing": ["site-context"],
+        "slurm-jobs": ["site-context", "analysis-context"],
+    }
+
+
+def test_project_inventory_json_has_schema_version(tmp_path: Path) -> None:
+    """Machine-readable plugin inventory exposes a stable schema version."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+    )
+
+    inventory = load_project_codex_plugin_inventory(tmp_path)
+    check_result = check_codex_plugin_inventory(inventory)
+
+    assert inventory.to_dict()["$schema"] == "schemas/codex-plugin-inventory.json"
+    assert inventory.to_dict()["schema_version"] == (
+        CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION
+    )
+    assert inventory.to_dict()["delegated_capabilities"] == {}
+    assert check_result.to_dict()["$schema"] == (
+        "schemas/codex-plugin-check-result.json"
+    )
+    assert check_result.to_dict()["schema_version"] == (
+        CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION
+    )
+    assert check_result.to_dict()["strict_ok"] is True
+    assert check_result.to_dict()["inventory"]["schema_version"] == (
+        CODEX_PLUGIN_INVENTORY_SCHEMA_VERSION
+    )
+
+
+def test_project_inventory_uses_adapter_alias_for_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Plugin recommendations work when simulator key and adapter name differ."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.production]\n"
+            'adapter = "emses"\n'
+            'resolver_mode = "package"\n'
+            'executable = "mpiemses3D"\n'
+        ),
+    )
+
+    inventory = load_project_codex_plugin_inventory(tmp_path)
+
+    assert inventory.simulator_names == ("production",)
+    assert [plugin.name for plugin in inventory.recommendations] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    assert inventory.recommendations[0].source_labels() == (
+        "simulator:emses",
+        "simulator:production",
+    )
+
+
+def test_project_inventory_includes_beach_adapter_recommendation(
+    tmp_path: Path,
+) -> None:
+    """BEACH projects recommend the BEACH Context plugin."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.beach]\n"
+            'adapter = "beach"\n'
+            'resolver_mode = "package"\n'
+            'executable = "beach"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is True
+    assert [plugin.name for plugin in result.inventory.recommendations] == [
+        "beach-context"
+    ]
+    assert result.inventory.delegated_capabilities()["run-diagnose"] == [
+        "beach-context"
+    ]
+    plugin_payload = result.to_dict()["inventory"]["recommendations"][0]
+    assert plugin_payload["display_name"] == "BEACH Context"
+    assert plugin_payload["source"] == "simulator:beach"
+    assert plugin_payload["sources"] == ["simulator:beach"]
+    assert "run-diagnose" in plugin_payload["capabilities"]
+    assert "output-analysis" in plugin_payload["capabilities"]
+    assert "cookbook" in plugin_payload["capabilities"]
+    assert result.to_dict()["inventory"]["delegated_capabilities"]["cookbook"] == [
+        "beach-context"
+    ]
+    assert result.to_dict()["inventory"]["delegated_capabilities"]["run-diagnose"] == [
+        "beach-context"
+    ]
+
+
+def test_project_inventory_includes_site_recommendations(tmp_path: Path) -> None:
+    """Site profile Codex plugin recommendations are included."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+        ),
+    )
+
+    inventory = load_project_codex_plugin_inventory(tmp_path)
+
+    assert inventory.site_name == "test-site"
+    assert [plugin.name for plugin in inventory.recommendations] == ["site-context"]
+    assert inventory.to_dict()["management"]["runops_installs_plugins"] is False
+
+
+def test_project_inventory_includes_simulator_config_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Project simulator config can recommend plugins without adapter changes."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.production]\n"
+            'adapter = "generic"\n'
+            'resolver_mode = "package"\n'
+            'executable = "solver"\n'
+            "\n[simulators.production.codex_plugins.production-context]\n"
+            'display_name = "Production Context"\n'
+            'reason = "Project-specific production workflow guidance."\n'
+            'install_hint = "codex plugin add production-context@project"\n'
+            'capabilities = ["case-design", "analysis-workflow"]\n'
+            'activation_hint = "Start a new Codex thread."\n'
+            'visibility = "private-or-gated"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is True
+    assert [plugin.name for plugin in result.inventory.recommendations] == [
+        "production-context"
+    ]
+    plugin_payload = result.to_dict()["inventory"]["recommendations"][0]
+    assert plugin_payload["source"] == "simulator:production"
+    assert plugin_payload["sources"] == ["simulator:production"]
+    assert plugin_payload["visibility"] == "private-or-gated"
+    assert plugin_payload["capabilities"] == ["case-design", "analysis-workflow"]
+
+
+def test_project_inventory_includes_project_config_recommendations(
+    tmp_path: Path,
+) -> None:
+    """runops.toml can recommend project-wide plugins without adapter changes."""
+    _write_project(
+        tmp_path,
+        project_toml=(
+            '[project]\nname = "plugin-demo"\ndescription = ""\n'
+            "\n[project.codex_plugins.analysis-context]\n"
+            'display_name = "Analysis Context"\n'
+            'reason = "Team analysis workflow guidance."\n'
+            'install_hint = "codex plugin add analysis-context@project"\n'
+            'capabilities = ["survey-design", "report-writing"]\n'
+            'activation_hint = "Start a new Codex thread."\n'
+            'visibility = "private-or-gated"\n'
+        ),
+        simulators_toml="[simulators]\n",
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is True
+    assert [plugin.name for plugin in result.inventory.recommendations] == [
+        "analysis-context"
+    ]
+    plugin_payload = result.to_dict()["inventory"]["recommendations"][0]
+    assert plugin_payload["source"] == "project:plugin-demo"
+    assert plugin_payload["sources"] == ["project:plugin-demo"]
+    assert plugin_payload["visibility"] == "private-or-gated"
+    assert plugin_payload["capabilities"] == ["survey-design", "report-writing"]
+
+
+def test_project_inventory_accepts_single_capability_string(
+    tmp_path: Path,
+) -> None:
+    """A single capability label may be written as a string."""
+    _write_project(
+        tmp_path,
+        project_toml=(
+            '[project]\nname = "plugin-demo"\ndescription = ""\n'
+            "\n[project.codex_plugins.analysis-context]\n"
+            'display_name = "Analysis Context"\n'
+            'reason = "Team analysis workflow guidance."\n'
+            'install_hint = "codex plugin add analysis-context@project"\n'
+            'capabilities = "report-writing"\n'
+        ),
+        simulators_toml="[simulators]\n",
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is True
+    assert result.inventory.recommendations[0].capabilities == ("report-writing",)
+    assert result.inventory.delegated_capabilities() == {
+        "report-writing": ["analysis-context"]
+    }
+
+
+def test_project_plugin_check_passes_complete_recommendations(tmp_path: Path) -> None:
+    """Complete adapter-provided recommendations pass metadata checks."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.emses]\n"
+            'adapter = "emses"\n'
+            'resolver_mode = "package"\n'
+            'executable = "mpiemses3D"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is True
+    assert result.issues == ()
+    payload = result.to_dict()
+    assert payload["strict_ok"] is True
+    assert payload["summary"]["recommendations"] == 2
+
+
+def test_project_plugin_check_warns_when_adapter_recommendations_cannot_be_collected(
+    tmp_path: Path,
+) -> None:
+    """Missing external adapters are visible without forcing installation."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.production]\n"
+            'adapter = "missing_external"\n'
+            'resolver_mode = "package"\n'
+            'executable = "missing-solver"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert result.to_dict()["strict_ok"] is False
+    assert result.inventory.recommendations == ()
+    assert [
+        (issue.severity, issue.plugin_name, issue.field) for issue in result.issues
+    ] == [("warning", "missing_external", "adapter")]
+    issue_payload = result.to_dict()["inventory"]["collection_issues"][0]
+    assert issue_payload["source"] == "simulator:production"
+    assert "could not be collected" in issue_payload["message"]
+
+
+def test_project_plugin_check_reports_malformed_simulator_config_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Malformed project-side simulator plugin tables are warning-level issues."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            '[simulators.production]\nadapter = "generic"\ncodex_plugins = ["broken"]\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [(issue.plugin_name, issue.field) for issue in result.issues] == [
+        ("production", "codex_plugins")
+    ]
+
+
+def test_project_plugin_check_reports_malformed_project_config_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Malformed project-level plugin tables are warning-level issues."""
+    _write_project(
+        tmp_path,
+        project_toml=(
+            '[project]\nname = "plugin-demo"\ndescription = ""\n'
+            'codex_plugins = ["broken"]\n'
+        ),
+        simulators_toml="[simulators]\n",
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [(issue.plugin_name, issue.field) for issue in result.issues] == [
+        ("plugin-demo", "codex_plugins")
+    ]
+    assert result.issues[0].source == "project:plugin-demo"
+
+
+def test_project_plugin_check_reports_malformed_site_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Malformed site plugin tables are warning-level issues."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+        site_toml=('[site]\nname = "test-site"\ncodex_plugins = ["broken"]\n'),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [(issue.plugin_name, issue.field) for issue in result.issues] == [
+        ("test-site", "codex_plugins")
+    ]
+    assert result.issues[0].source == "site:test-site"
+
+
+def test_project_plugin_check_reports_malformed_simulator_capabilities(
+    tmp_path: Path,
+) -> None:
+    """Malformed simulator capability labels are warning-level metadata issues."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.production]\n"
+            'adapter = "generic"\n'
+            'resolver_mode = "package"\n'
+            'executable = "solver"\n'
+            "\n[simulators.production.codex_plugins.production-context]\n"
+            'display_name = "Production Context"\n'
+            'reason = "Project-specific production workflow guidance."\n'
+            'install_hint = "codex plugin add production-context@project"\n'
+            'capabilities = { role = "broken" }\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [plugin.name for plugin in result.inventory.recommendations] == [
+        "production-context"
+    ]
+    assert result.inventory.recommendations[0].capabilities == ()
+    assert [
+        (issue.severity, issue.plugin_name, issue.field, issue.source)
+        for issue in result.issues
+    ] == [("warning", "production-context", "capabilities", "simulator:production")]
+    assert "non-empty strings" in result.issues[0].message
+
+
+def test_project_plugin_check_reports_malformed_project_capabilities(
+    tmp_path: Path,
+) -> None:
+    """Malformed project-wide capability labels are warning-level metadata issues."""
+    _write_project(
+        tmp_path,
+        project_toml=(
+            '[project]\nname = "plugin-demo"\ndescription = ""\n'
+            "\n[project.codex_plugins.analysis-context]\n"
+            'display_name = "Analysis Context"\n'
+            'reason = "Team analysis workflow guidance."\n'
+            'install_hint = "codex plugin add analysis-context@project"\n'
+            'capabilities = [""]\n'
+        ),
+        simulators_toml="[simulators]\n",
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert result.inventory.recommendations[0].capabilities == ()
+    assert [
+        (issue.severity, issue.plugin_name, issue.field, issue.source)
+        for issue in result.issues
+    ] == [("warning", "analysis-context", "capabilities", "project:plugin-demo")]
+
+
+def test_project_plugin_check_reports_malformed_site_capabilities(
+    tmp_path: Path,
+) -> None:
+    """Malformed site capability labels are warning-level metadata issues."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+            'capabilities = { role = "broken" }\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert result.inventory.recommendations[0].capabilities == ()
+    assert [
+        (issue.severity, issue.plugin_name, issue.field, issue.source)
+        for issue in result.issues
+    ] == [("warning", "site-context", "capabilities", "site:test-site")]
+
+
+def test_project_plugin_check_reports_malformed_site_plugin_metadata(
+    tmp_path: Path,
+) -> None:
+    """Malformed site plugin metadata is not silently dropped."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins]\n"
+            'site-context = "broken"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [(issue.plugin_name, issue.field) for issue in result.issues] == [
+        ("site-context", "codex_plugins")
+    ]
+    assert result.issues[0].source == "site:test-site"
+
+
+def test_project_plugin_check_reports_incomplete_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Incomplete site-provided recommendation metadata is reported."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.incomplete]\n"
+            'display_name = "Incomplete Plugin"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is False
+    assert [issue.field for issue in result.issues] == ["reason", "install_hint"]
+    assert {issue.severity for issue in result.issues} == {"error"}
+
+
+def test_project_plugin_check_warns_on_unknown_visibility(tmp_path: Path) -> None:
+    """Unknown visibility is a warning, not an error."""
+    _write_project(
+        tmp_path,
+        simulators_toml="[simulators]\n",
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.site-context]\n"
+            'display_name = "Site Context"\n'
+            'reason = "Site-local workflow guidance."\n'
+            'install_hint = "codex plugin add site-context@test"\n'
+            'visibility = "private"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [(issue.severity, issue.field) for issue in result.issues] == [
+        ("warning", "visibility")
+    ]
+
+
+def test_project_plugin_check_warns_on_conflicting_duplicate_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Duplicate plugin recommendations keep the first entry and warn on drift."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.emses]\n"
+            'adapter = "emses"\n'
+            'resolver_mode = "package"\n'
+            'executable = "mpiemses3D"\n'
+        ),
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.mpiemses3d-context]\n"
+            'display_name = "MPIEMSES3D Context"\n'
+            'reason = "Site-local MPIEMSES3D guidance."\n'
+            'install_hint = "codex plugin add mpiemses3d-context@site"\n'
+            'activation_hint = "Start a new Codex thread."\n'
+            'visibility = "private-or-gated"\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is False
+    assert [plugin.name for plugin in result.inventory.recommendations] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    assert [(issue.severity, issue.field) for issue in result.issues] == [
+        ("warning", "duplicate")
+    ]
+    assert result.to_dict()["inventory"]["collection_issues"][0]["field"] == (
+        "duplicate"
+    )
+
+
+def test_project_plugin_check_merges_duplicate_sources_and_capabilities(
+    tmp_path: Path,
+) -> None:
+    """Duplicate recommendations can add delegated roles without adapter edits."""
+    _write_project(
+        tmp_path,
+        simulators_toml=(
+            "[simulators.emses]\n"
+            'adapter = "emses"\n'
+            'resolver_mode = "package"\n'
+            'executable = "mpiemses3D"\n'
+        ),
+        site_toml=(
+            '[site]\nname = "test-site"\n'
+            "[site.codex_plugins.mpiemses3d-context]\n"
+            'display_name = "MPIEMSES3D Context"\n'
+            'reason = "MPIEMSES3D input review, parameter design, run diagnosis, '
+            'output analysis, and simulator learning guides."\n'
+            'install_hint = "pip install mpiemses3d-tools\\n'
+            'mpiemses-codex-plugin install"\n'
+            'activation_hint = "Open Codex /plugins, install '
+            '`MPIEMSES3D Context`, then start a new Codex thread."\n'
+            'visibility = "private-or-gated"\n'
+            'capabilities = ["site-runbook", "run-diagnose"]\n'
+        ),
+    )
+
+    result = check_codex_plugin_inventory(load_project_codex_plugin_inventory(tmp_path))
+
+    assert result.ok is True
+    assert result.ok_with_strict() is True
+    assert [plugin.name for plugin in result.inventory.recommendations] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    plugin = result.inventory.recommendations[0]
+    assert plugin.source == "simulator:emses, site:test-site"
+    assert plugin.source_labels() == ("simulator:emses", "site:test-site")
+    assert plugin.capabilities == (
+        "input-review",
+        "parameter-design",
+        "run-diagnose",
+        "output-analysis",
+        "method-summary",
+        "simulator-guide",
+        "cookbook",
+        "issue-report",
+        "site-runbook",
+    )
+    assert result.inventory.delegated_capabilities()["cookbook"] == [
+        "mpiemses3d-context"
+    ]
+    assert result.inventory.delegated_capabilities()["site-runbook"] == [
+        "mpiemses3d-context"
+    ]
+    plugin_payload = result.to_dict()["inventory"]["recommendations"][0]
+    assert plugin_payload["source"] == "simulator:emses, site:test-site"
+    assert plugin_payload["sources"] == ["simulator:emses", "site:test-site"]
+    assert not result.issues

--- a/tests/test_core/test_schemas.py
+++ b/tests/test_core/test_schemas.py
@@ -23,8 +23,75 @@ def test_runops_schema_is_the_project_schema() -> None:
 
     assert schema["title"] == "runops.toml"
     assert "project" in schema["properties"]
+    project_props = schema["properties"]["project"]["properties"]
+    assert "codex_plugins" in project_props
+    plugin_schema = project_props["codex_plugins"]["additionalProperties"]
+    assert plugin_schema["$ref"] == "codex-plugin-recommendation.json"
     assert "harness" in schema["properties"]
     assert "upstream_feedback" in schema["properties"]["harness"]["properties"]
+
+
+def test_codex_plugin_recommendation_schema_defines_shared_contract() -> None:
+    """Plugin recommendation metadata is defined once for all TOML schemas."""
+    schema = _load_schema("codex-plugin-recommendation.json")
+
+    assert schema["title"] == "Codex plugin recommendation"
+    assert schema["required"] == ["display_name", "reason", "install_hint"]
+    assert "capabilities" in schema["properties"]
+
+
+def test_codex_plugin_inventory_schema_defines_json_output_contract() -> None:
+    """Plugin inventory JSON output has a schema for external clients."""
+    schema = _load_schema("codex-plugin-inventory.json")
+    recommendation = schema["definitions"]["recommendation"]
+
+    assert schema["title"] == "Codex plugin inventory"
+    assert "$schema" in schema["required"]
+    assert schema["properties"]["$schema"]["const"] == (
+        "schemas/codex-plugin-inventory.json"
+    )
+    assert schema["properties"]["schema_version"]["const"] == 1
+    assert "delegated_capabilities" in schema["required"]
+    assert "sources" in recommendation["required"]
+    assert "capabilities" in recommendation["required"]
+
+
+def test_codex_plugin_check_result_schema_wraps_inventory_contract() -> None:
+    """Plugin check JSON output references the inventory schema."""
+    schema = _load_schema("codex-plugin-check-result.json")
+
+    assert schema["title"] == "Codex plugin check result"
+    assert "$schema" in schema["required"]
+    assert schema["properties"]["$schema"]["const"] == (
+        "schemas/codex-plugin-check-result.json"
+    )
+    assert schema["properties"]["schema_version"]["const"] == 1
+    assert schema["properties"]["inventory"]["$ref"] == ("codex-plugin-inventory.json")
+    assert schema["properties"]["issues"]["items"]["$ref"] == (
+        "codex-plugin-inventory.json#/definitions/issue"
+    )
+
+
+def test_simulators_schema_includes_plugin_recommendation_metadata() -> None:
+    """simulators.toml schema exposes simulator-scoped plugin metadata."""
+    schema = _load_schema("simulators.json")
+    simulator_schema = schema["properties"]["simulators"]["additionalProperties"]
+    plugin_schema = simulator_schema["properties"]["codex_plugins"][
+        "additionalProperties"
+    ]
+
+    assert plugin_schema["$ref"] == "codex-plugin-recommendation.json"
+
+
+def test_site_schema_includes_plugin_recommendation_metadata() -> None:
+    """site.toml schema exposes site-scoped plugin metadata."""
+    schema = _load_schema("site.json")
+    site_props = schema["properties"]["site"]["properties"]
+    plugin_schema = site_props["codex_plugins"]["additionalProperties"]
+
+    assert schema["title"] == "site.toml"
+    assert "simulators" in site_props
+    assert plugin_schema["$ref"] == "codex-plugin-recommendation.json"
 
 
 def test_case_schema_matches_current_case_sections() -> None:

--- a/tests/test_core/test_site.py
+++ b/tests/test_core/test_site.py
@@ -116,6 +116,7 @@ class TestLoadSiteProfile:
             'display_name = "Test Plugin"\n'
             'visibility = "private-or-gated"\n'
             'reason = "Site-specific workflow guidance."\n'
+            'capabilities = ["host-role-routing", "safe-workflows"]\n'
             'install_hint = "codex plugin add test-plugin@test-marketplace"\n'
             'activation_hint = "Start a new Codex thread."\n',
             encoding="utf-8",
@@ -128,6 +129,7 @@ class TestLoadSiteProfile:
         assert plugin.name == "test-plugin"
         assert plugin.display_name == "Test Plugin"
         assert plugin.visibility == "private-or-gated"
+        assert plugin.capabilities == ("host-role-routing", "safe-workflows")
         assert "codex plugin add" in plugin.install_hint
 
     def test_fallback_to_launchers_toml(self, tmp_path: Path) -> None:
@@ -218,10 +220,15 @@ class TestSaveSiteProfile:
                     activation_hint="Start a new Codex thread.",
                     visibility="private-or-gated",
                     source="site:camphor3",
+                    capabilities=("host-role-routing", "slurm-jobs"),
                 )
             ],
         )
         save_site_profile(tmp_path, original)
+
+        content = (tmp_path / "site.toml").read_text(encoding="utf-8")
+        assert content.startswith("#:schema ")
+        assert "/schemas/site.json" in content
 
         loaded = load_site_profile(tmp_path)
         assert loaded.name == original.name

--- a/tests/test_harness/test_codex.py
+++ b/tests/test_harness/test_codex.py
@@ -120,6 +120,7 @@ def test_bundle_emits_codex_config_and_agents_skills() -> None:
     assert "推奨 Codex plugins" in agents
     assert "MPIEMSES3D Context" in agents
     assert "emout Context" in agents
+    assert "委譲役割: input-review, parameter-design" in agents
     assert "$research-agenda" in agents
     assert "$summarize-script" in agents
     assert "$patch-runops" in agents
@@ -177,6 +178,25 @@ def test_bundle_emits_codex_config_and_agents_skills() -> None:
     assert "状態確認だけで応答を終えない" in claude_setup
     assert 'git commit -m "chore: scaffold runops project"' in claude_setup
     assert "{{ skill_prefix }}" not in codex_setup
+
+
+def test_bundle_uses_simulator_adapter_alias_for_plugin_recommendations() -> None:
+    """Direct harness generation keeps simulator names decoupled from adapters."""
+    bundle = build_harness_bundle(
+        "demo",
+        ["production"],
+        simulator_configs={
+            "production": {
+                "adapter": "emses",
+                "resolver_mode": "package",
+                "executable": "mpiemses3D",
+            }
+        },
+    )
+
+    agents = bundle.files["AGENTS.md"]
+    assert "MPIEMSES3D Context" in agents
+    assert "`mpiemses3d-context`" in agents
 
 
 def test_bundle_does_not_emit_project_local_codex_prompts() -> None:

--- a/tests/test_mcp/test_registry.py
+++ b/tests/test_mcp/test_registry.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from runops.mcp.registry import (
+    CODEX_PLUGIN_POLICY,
     REQUIRED_RUNOPS_TOOLS,
     all_tool_specs,
+    capabilities_payload,
     conformance_report,
     exposed_tool_specs,
 )
@@ -34,3 +36,27 @@ def test_unsafe_action_tools_remain_disabled_by_default() -> None:
         assert spec.exposed is False
         assert spec.safety.requires_confirmation is True
         assert spec.safety.confirmation_field == "confirm"
+
+
+def test_capabilities_payload_exposes_codex_plugin_policy() -> None:
+    payload = capabilities_payload()
+    exposed = {spec.name for spec in exposed_tool_specs()}
+
+    assert payload["codex_plugin_policy"] == CODEX_PLUGIN_POLICY
+    assert payload["codex_plugin_policy"]["inventory_schema_version"] == 1
+    assert payload["codex_plugin_policy"]["inventory_schema"] == (
+        "schemas/codex-plugin-inventory.json"
+    )
+    assert payload["codex_plugin_policy"]["check_result_schema"] == (
+        "schemas/codex-plugin-check-result.json"
+    )
+    assert CODEX_PLUGIN_POLICY["project_tool"] in exposed
+    assert "recommendations" in payload["codex_plugin_policy"]["inventory_fields"]
+    assert "$schema" in payload["codex_plugin_policy"]["inventory_fields"]
+    assert "strict_ok" in payload["codex_plugin_policy"]["check_result_fields"]
+    assert "$schema" in payload["codex_plugin_policy"]["check_result_fields"]
+    assert "sources" in payload["codex_plugin_policy"]["recommendation_fields"]
+    assert (
+        payload["codex_plugin_policy"]["delegated_capabilities_field"]
+        == "delegated_capabilities"
+    )

--- a/tests/test_mcp/test_server.py
+++ b/tests/test_mcp/test_server.py
@@ -48,6 +48,7 @@ _TOOL_ATTRS = {
     "runops.project.list": "project_list",
     "runops.project.status": "project_status",
     "runops.project.inspect": "project_inspect",
+    "runops.project.plugins": "project_plugins",
     "runops.project.doctor": "project_doctor",
     "runops.publication.exports.list": "publication_exports_list",
     "runops.publication.export.inspect": "publication_export_inspect",
@@ -100,6 +101,13 @@ def test_registered_tool_wrappers_delegate_to_domain_tools(
     assert fake.tools["runops.project.list"]["callback"](project_root="root") == {
         "stub": "runops.project.list",
         "kwargs": {"project_root": "root"},
+    }
+    assert fake.tools["runops.project.plugins"]["callback"](
+        project_root="root",
+        strict=True,
+    ) == {
+        "stub": "runops.project.plugins",
+        "kwargs": {"project_root": "root", "strict": True},
     }
     assert fake.tools["runops.publication.exports.list"]["callback"](
         project_root="root",
@@ -283,6 +291,7 @@ def test_registered_tool_wrappers_delegate_to_domain_tools(
         "runops.paper.request.plan",
         "runops.paper.requests.list",
         "runops.project.list",
+        "runops.project.plugins",
         "runops.publication.export.inspect",
         "runops.publication.exports.list",
         "runops.run.list",

--- a/tests/test_mcp/test_tools.py
+++ b/tests/test_mcp/test_tools.py
@@ -107,6 +107,39 @@ def test_health_returns_contract_envelope() -> None:
     assert result["data"]["healthy"] is True
 
 
+def test_provider_info_exposes_codex_plugin_policy() -> None:
+    result = tools.provider_info()
+
+    policy = result["data"]["codex_plugin_policy"]
+    assert policy["recommendations_advisory"] is True
+    assert policy["metadata_checks_supported"] is True
+    assert policy["installs_plugins"] is False
+    assert policy["enables_plugins"] is False
+    assert policy["inspects_user_install_state"] is False
+    assert policy["inventory_schema_version"] == 1
+    assert policy["inventory_schema"] == "schemas/codex-plugin-inventory.json"
+    assert policy["check_result_schema"] == "schemas/codex-plugin-check-result.json"
+    assert policy["project_tool"] == "runops.project.plugins"
+    assert "recommendations" in policy["inventory_fields"]
+    assert "$schema" in policy["inventory_fields"]
+    assert "strict_ok" in policy["check_result_fields"]
+    assert "$schema" in policy["check_result_fields"]
+    assert "sources" in policy["recommendation_fields"]
+    assert policy["source_fields"]["sources"] == "machine-readable source label list"
+
+
+def test_capabilities_exposes_codex_plugin_policy() -> None:
+    result = tools.capabilities()
+
+    policy = result["data"]["codex_plugin_policy"]
+    assert policy["recommendations_advisory"] is True
+    assert policy["metadata_checks_supported"] is True
+    assert policy["installs_plugins"] is False
+    assert policy["activation_scope"] == "user-local Codex environment"
+    assert policy["inventory_schema_version"] == 1
+    assert policy["delegated_capabilities_field"] == "delegated_capabilities"
+
+
 def test_project_status_summarizes_project(tmp_path: Path) -> None:
     project_root = _make_project(tmp_path)
     _make_run(project_root)
@@ -116,6 +149,156 @@ def test_project_status_summarizes_project(tmp_path: Path) -> None:
     assert result["status"] == "ok"
     assert result["project"]["id"] == "mcp-demo"
     assert result["data"]["runs"]["total"] == 1
+
+
+def test_project_inspect_includes_codex_plugin_context(tmp_path: Path) -> None:
+    """Detailed MCP project context exposes advisory plugin recommendations."""
+    project_root = _make_project(tmp_path)
+    (project_root / "simulators.toml").write_text(
+        "[simulators.emses]\n"
+        'adapter = "emses"\n'
+        'resolver_mode = "package"\n'
+        'executable = "mpiemses3D"\n',
+        encoding="utf-8",
+    )
+
+    result = tools.project_inspect(project_root=str(project_root))
+
+    assert result["status"] == "ok"
+    plugins = result["data"]["context"]["codex_plugins"]
+    assert plugins["management"]["runops_installs_plugins"] is False
+    assert [plugin["name"] for plugin in plugins["recommendations"]] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    assert plugins["recommendations"][0]["sources"] == ["simulator:emses"]
+
+
+def test_project_plugins_returns_advisory_check_result(tmp_path: Path) -> None:
+    """MCP exposes plugin recommendations and metadata checks directly."""
+    project_root = _make_project(tmp_path)
+    (project_root / "simulators.toml").write_text(
+        "[simulators.emses]\n"
+        'adapter = "emses"\n'
+        'resolver_mode = "package"\n'
+        'executable = "mpiemses3D"\n',
+        encoding="utf-8",
+    )
+
+    result = tools.project_plugins(project_root=str(project_root))
+
+    assert result["status"] == "ok"
+    assert result["tool"] == "runops.project.plugins"
+    assert result["data"]["$schema"] == "schemas/codex-plugin-check-result.json"
+    assert result["data"]["schema_version"] == 1
+    assert result["data"]["ok"] is True
+    assert result["data"]["strict_ok"] is True
+    assert result["data"]["inventory"]["$schema"] == (
+        "schemas/codex-plugin-inventory.json"
+    )
+    assert result["data"]["inventory"]["management"]["runops_installs_plugins"] is False
+    assert result["data"]["inventory"]["delegated_capabilities"][
+        "parameter-design"
+    ] == ["mpiemses3d-context"]
+    assert [
+        plugin["name"] for plugin in result["data"]["inventory"]["recommendations"]
+    ] == [
+        "mpiemses3d-context",
+        "emout-context",
+    ]
+    assert result["data"]["inventory"]["recommendations"][0]["sources"] == [
+        "simulator:emses"
+    ]
+
+
+def test_project_plugins_reports_metadata_errors(tmp_path: Path) -> None:
+    """Incomplete plugin metadata is surfaced as MCP errors."""
+    project_root = _make_project(tmp_path)
+    (project_root / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.incomplete]\n"
+        'display_name = "Incomplete Plugin"\n',
+        encoding="utf-8",
+    )
+
+    result = tools.project_plugins(project_root=str(project_root))
+
+    assert result["status"] == "error"
+    assert result["data"]["ok"] is False
+    assert result["data"]["summary"]["errors"] == 2
+    assert [item["code"] for item in result["errors"]] == [
+        "codex_plugin_metadata_error",
+        "codex_plugin_metadata_error",
+    ]
+
+
+def test_project_plugins_strict_reports_warning_only_checks(
+    tmp_path: Path,
+) -> None:
+    """Strict mode keeps warning-only checks visible for MCP clients."""
+    project_root = _make_project(tmp_path)
+    (project_root / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.site-context]\n"
+        'display_name = "Site Context"\n'
+        'reason = "Site-local workflow guidance."\n'
+        'install_hint = "codex plugin add site-context@test"\n'
+        'visibility = "private"\n',
+        encoding="utf-8",
+    )
+
+    result = tools.project_plugins(project_root=str(project_root), strict=True)
+
+    assert result["status"] == "warning"
+    assert result["data"]["ok"] is True
+    assert result["data"]["strict_ok"] is False
+    assert result["data"]["strict"] is True
+    assert result["warnings"][0]["severity"] == "high"
+
+
+def test_project_plugins_warns_when_adapter_recommendations_cannot_be_collected(
+    tmp_path: Path,
+) -> None:
+    """MCP surfaces missing external adapters as advisory collection warnings."""
+    project_root = _make_project(tmp_path)
+    (project_root / "simulators.toml").write_text(
+        "[simulators.production]\n"
+        'adapter = "missing_external"\n'
+        'resolver_mode = "package"\n'
+        'executable = "missing-solver"\n',
+        encoding="utf-8",
+    )
+
+    result = tools.project_plugins(project_root=str(project_root))
+
+    assert result["status"] == "warning"
+    assert result["data"]["ok"] is True
+    assert result["data"]["strict_ok"] is False
+    assert result["data"]["issues"][0]["field"] == "adapter"
+    assert result["warnings"][0]["code"] == "codex_plugin_metadata_warning"
+    assert "missing_external.adapter" in result["warnings"][0]["message"]
+
+
+def test_project_doctor_reports_codex_plugin_metadata_errors(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """MCP doctor includes project-side Codex plugin recommendation checks."""
+    project_root = _make_project(tmp_path)
+    (project_root / "site.toml").write_text(
+        '[site]\nname = "test-site"\n'
+        "[site.codex_plugins.incomplete]\n"
+        'display_name = "Incomplete Plugin"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(tools.shutil, "which", lambda _cmd: "/usr/bin/sbatch")
+
+    result = tools.project_doctor(project_root=str(project_root))
+
+    assert result["status"] == "warning"
+    checks = {check["name"]: check for check in result["data"]["checks"]}
+    assert checks["codex_plugins"]["ok"] is False
+    assert "2 error(s)" in checks["codex_plugins"]["message"]
 
 
 def test_run_list_filters_by_status_and_tag(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add advisory Codex plugin inventory/check contracts for runops projects
- expose plugin recommendations through CLI, lint, context, MCP, JSON schemas, setup/init/update-harness, and generated harness docs
- keep simulator cookbook and long simulator guidance delegated to simulator-side plugins, with refs as an optional fallback mirror

## Validation

- `tssrun -p eb uv run pytest tests/test_core/test_plugins.py tests/test_cli/test_plugins.py tests/test_core/test_context.py tests/test_mcp/test_tools.py -q`
- `tssrun -p eb uv run ruff format --check src/ tests/`
- `tssrun -p eb uv run ruff check src/ tests/`
- `tssrun -p eb uv run mypy src/`
- Earlier full gate before the cookbook clarification: `tssrun -p eb uv run pytest tests/ -q` and branch coverage with `--cov-fail-under=80`
