### PR TITLE
[codex] docs: update plugin delegation guidance

### DIFF
--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -20,7 +20,8 @@ description: "Reflect code changes into documentation. Scan recent commits or st
 | `.codex/rules/architecture.md` | アーキテクチャ原則 | レイヤ構造変更時 |
 | `docs/toml-reference.md` | TOML 設定リファレンス | case.toml / survey.toml 等のフィールド追加時 |
 | `docs/extending.md` | 拡張ガイド | Adapter / Launcher の追加方法変更時 |
-| `docs/project-flow.md` | プロジェクトフロー | ワークフロー変更時 |
+| `docs/agent-user-guide.md` / `docs/get-started-with-agent.md` | Agent 向けワークフロー | plugin 委譲・初期導線変更時 |
+| `docs/layers/*.md` | レイヤ別設計・運用 | knowledge / harness / interface 変更時 |
 | `src/runops/sites/*.md` | サイト固有ドキュメント | サイト機能追加・制限事項更新時 |
 
 ### プロジェクト側ハーネス (runops ユーザー向け)
@@ -52,7 +53,7 @@ git diff --stat
 |-----------|---------|
 | CLI オプション追加・変更 | `commands.md`, `toml-reference.md` |
 | TOML フィールド追加 | `toml-reference.md` |
-| 新スキル追加 | プロジェクト側テンプレートの AGENTS.md (スキル一覧があれば) |
+| 新スキル追加 | プロジェクト側テンプレートの AGENTS.md / CLAUDE.md (スキル一覧があれば) |
 | サイト固有の変更 | `src/runops/sites/<site>.md` |
 | Adapter / Launcher 追加 | `docs/extending.md` |
 | アーキテクチャ変更 | `architecture.md` |

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -17,11 +17,13 @@
 | `runops mcp serve --transport streamable-http` | MCP provider を Streamable HTTP で起動 |
 | `runops mcp check` | MCP registry / safety contract の軽量検査 |
 | `runops mcp tools --json` | MCP tool metadata を JSON で表示 |
+| `runops mcp resources --json` | MCP resources metadata を JSON で表示 (現状は空) |
+| `runops mcp prompts --json` | MCP prompts metadata を JSON で表示 (現状は空) |
 | `runops config show` | 設定表示 |
 | `runops config add-simulator` | シミュレータ追加 (対話型) |
 | `runops config add-launcher` | ランチャー追加 (対話型) |
 | `runops update` | シミュレータパッケージのアップグレード |
-| `runops update-harness` | ハーネスファイル再生成 |
+| `runops update-harness [--plan] [--apply-chain]` | ハーネスファイル再生成 / versioned chain 更新 |
 | `runops update-refs` | 任意 refs mirror 更新 + ナレッジインデックス再生成 |
 
 ## Case / Run 操作

--- a/.claude/rules/knowledge-layer.md
+++ b/.claude/rules/knowledge-layer.md
@@ -7,7 +7,7 @@ AI エージェントがシミュレーションを自律的に行うための�
 
 | 種類 | 保存先 | 更新方法 |
 |------|--------|----------|
-| シミュレータ知識 | simulator/environment plugin + `.runops/knowledge/` + 任意の `refs/` mirror | plugin install/update, `runops knowledge source sync`, `runops update-refs` |
+| シミュレータ知識 | simulator/environment plugin + `.runops/knowledge/` + 任意の `refs/` fallback mirror | plugin install/update, `runops knowledge source sync`, `runops update-refs` |
 | 外部共有知識 | `runops.toml` の `[knowledge]` | `knowledge source attach/sync` |
 | 実行環境 | `.runops/environment.toml` | `runops doctor` |
 | 研究意図 | `campaign.toml` | ユーザーが記述 |
@@ -43,5 +43,5 @@ runops knowledge source sync
 runops knowledge source render
 ```
 
-- `runops init` 時に GitHub の `*shared_knowledge*` リポジトリを自動検索し接続
+- `runops init` の対話時は GitHub の `*shared_knowledge*` リポジトリを候補表示し、選択されたものだけ接続
 - `runops setup` 時は `runops.toml` に設定された知識ソースを自動同期

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -20,16 +20,18 @@ description: "Reflect code changes into documentation. Scan recent commits or st
 | `.claude/rules/architecture.md` | アーキテクチャ原則 | レイヤ構造変更時 |
 | `docs/toml-reference.md` | TOML 設定リファレンス | case.toml / survey.toml 等のフィールド追加時 |
 | `docs/extending.md` | 拡張ガイド | Adapter / Launcher の追加方法変更時 |
-| `docs/project-flow.md` | プロジェクトフロー | ワークフロー変更時 |
+| `docs/agent-user-guide.md` / `docs/get-started-with-agent.md` | Agent 向けワークフロー | plugin 委譲・初期導線変更時 |
+| `docs/layers/*.md` | レイヤ別設計・運用 | knowledge / harness / interface 変更時 |
 | `src/runops/sites/*.md` | サイト固有ドキュメント | サイト機能追加・制限事項更新時 |
 
 ### プロジェクト側ハーネス (runops ユーザー向け)
 
 | テンプレート | 内容 | 更新タイミング |
 |------------|------|---------------|
-| `src/runops/templates/agent.md` | プロジェクト側 CLAUDE.md | コマンド体系変更時 |
-| `src/runops/templates/scaffold/rules/runops-workflow.md` | ワークフロー rule | コマンド追加時 |
-| `src/runops/templates/scaffold/rules/cookbook.md` | cookbook | 頻出パターン追加時 |
+| `src/runops/templates/harness/codex/AGENTS.md.j2` | プロジェクト側 AGENTS.md | コマンド体系変更時 |
+| `src/runops/templates/harness/claude/CLAUDE.md.j2` | プロジェクト側 CLAUDE.md | コマンド体系変更時 |
+| `src/runops/templates/harness/shared/rules/*.md.j2` | 共通 rule | ワークフロー・cookbook 変更時 |
+| `src/runops/templates/skills/*/SKILL.md` | プロジェクト側スキル | 定型作業・コマンド変更時 |
 
 ## 手順
 
@@ -51,7 +53,7 @@ git diff --stat
 |-----------|---------|
 | CLI オプション追加・変更 | `commands.md`, `toml-reference.md` |
 | TOML フィールド追加 | `toml-reference.md` |
-| 新スキル追加 | プロジェクト側テンプレートの CLAUDE.md (スキル一覧があれば) |
+| 新スキル追加 | プロジェクト側テンプレートの AGENTS.md / CLAUDE.md (スキル一覧があれば) |
 | サイト固有の変更 | `src/runops/sites/<site>.md` |
 | Adapter / Launcher 追加 | `docs/extending.md` |
 | アーキテクチャ変更 | `architecture.md` |
@@ -70,5 +72,5 @@ git diff --stat
 
 - ドキュメントの書き方や文体は既存部分に合わせる
 - 日本語ドキュメントと英語ドキュメントの両方を更新する
-- ハーネス二重構造に注意: 開発者向け (`.claude/`) とプロジェクト側 (`src/runops/templates/`) は別物
+- ハーネス二重構造に注意: 開発者向け (`.claude/`, `.codex/`, `.agents/skills/`) とプロジェクト側 (`src/runops/templates/`) は別物
 - `AGENTS.md` / `CLAUDE.md` は 150 行程度を目安に短く保つ。長いコマンド表は rules、定型手順は skills に置く

--- a/.codex/rules/commands.md
+++ b/.codex/rules/commands.md
@@ -18,11 +18,13 @@
 | `runo mcp serve --transport streamable-http` | MCP provider を Streamable HTTP で起動 |
 | `runo mcp check` | MCP registry / safety contract の軽量検査 |
 | `runo mcp tools --json` | MCP tool metadata を JSON で表示 |
+| `runo mcp resources --json` | MCP resources metadata を JSON で表示 (現状は空) |
+| `runo mcp prompts --json` | MCP prompts metadata を JSON で表示 (現状は空) |
 | `runo config show` | 設定表示 |
 | `runo config add-simulator` | シミュレータ追加 (対話型) |
 | `runo config add-launcher` | ランチャー追加 (対話型) |
 | `runo update` | シミュレータパッケージのアップグレード |
-| `runo update-harness` | ハーネスファイル再生成 |
+| `runo update-harness [--plan] [--apply-chain]` | ハーネスファイル再生成 / versioned chain 更新 |
 | `runo update-refs` | 任意 refs mirror 更新 + ナレッジインデックス再生成 |
 
 ## Case / Run 操作

--- a/.codex/rules/knowledge-layer.md
+++ b/.codex/rules/knowledge-layer.md
@@ -7,7 +7,7 @@ AI エージェントがシミュレーションを自律的に行うための�
 
 | 種類 | 保存先 | 更新方法 |
 |------|--------|----------|
-| シミュレータ知識 | simulator/environment plugin + `.runops/knowledge/` + 任意の `refs/` mirror | plugin install/update, `runo knowledge source sync`, `runo update-refs` |
+| シミュレータ知識 | simulator/environment plugin + `.runops/knowledge/` + 任意の `refs/` fallback mirror | plugin install/update, `runo knowledge source sync`, `runo update-refs` |
 | 外部共有知識 | `runops.toml` の `[knowledge]` | `knowledge source attach/sync` |
 | 実行環境 | `.runops/environment.toml` | `runo doctor` |
 | 研究意図 | `campaign.toml` | ユーザーが記述 |
@@ -43,5 +43,5 @@ runo knowledge source sync
 runo knowledge source render
 ```
 
-- `runo init` 時に GitHub の `*shared_knowledge*` リポジトリを自動検索し接続
+- `runo init` の対話時は GitHub の `*shared_knowledge*` リポジトリを候補表示し、選択されたものだけ接続
 - `runo setup` 時は `runops.toml` に設定された知識ソースを自動同期

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,8 @@ project-state に影響する breaking change は `docs/migrations/v0.md` に移
 | `runo --version` | version 確認 |
 | `runo init` / `setup` / `doctor` | プロジェクト管理 |
 | `runo context --json` / `runo lint` | project context と health check |
-| `runo mcp serve` / `mcp check` / `mcp tools --json` | MCP provider の起動・検査 |
-| `runo update-harness --plan/apply-chain` | project harness の versioned chain 更新 |
+| `runo mcp serve` / `mcp check` / `mcp tools/resources/prompts --json` | MCP provider の起動・検査 |
+| `runo update-harness --plan` / `--apply-chain` | project harness の versioned chain 更新 |
 | `runo migrate list/show/apply` | project-state migration |
 | `runo case new` / `runs create` / `runs sweep` | case / run 生成 |
 | `runo runs submit [--all] [-qn] [--qos] [--afterok] [--yes]` | ジョブ投入 (`--all` は確認付き、`--yes` で省略) |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ project state の全体像は [docs/layers/README.md](docs/layers/README.md) に
 
 Agent が主に行うこと:
 
-- project context、既存 notes、materials、refs、environment を読む
+- project context、推奨 plugin、既存 notes、materials、environment を読む
+- 必要な場合だけ、明示的 knowledge source や任意の `refs/` fallback mirror を参照する
 - `campaign.toml`、case、survey の草案を作る
 - run 生成、submit、sync、status、log、analysis を runops 経由で進める
 - `notes/YYYY-MM-DD.md`、`notes/reports/`、`research/agenda.md` を更新する
@@ -104,7 +105,7 @@ project/
   notes/                 # append-only lab notebook と refined reports
   research/agenda.md     # 現在の研究判断
   materials/             # papers, manuals, figures, snippets
-  refs/                  # simulator docs / external knowledge sources
+  refs/                  # optional fallback mirrors / external knowledge mounts
   .runops/               # environment, generated Agent context, facts
   .claude/ .agents/ .codex/
                          # Agent harness, skills, rules, permissions
@@ -132,6 +133,7 @@ Agent は確認前に、対象 run、queue、資源量、想定 core-hour、変�
 ```bash
 uvx --from runops runo init
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 既存 project:
@@ -140,6 +142,7 @@ uvx --from runops runo doctor
 uvx --from runops runo setup https://github.com/user/my-project.git
 cd my-project
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 ここまで終わったら、CLI を順に叩くのではなく Agent に研究内容を渡します。
@@ -169,7 +172,7 @@ uv run mypy src/
 - [Execution Kernel](docs/layers/execution-kernel.md) — run / submit / sync / manifest
 - [解析層](docs/layers/analysis.md) — 解析・可視化成果物の運用
 - [研究判断層](docs/layers/research.md) — `research/agenda.md`
-- [知識層](docs/layers/knowledge.md) — notes / materials / refs / knowledge
+- [知識層](docs/layers/knowledge.md) — plugin / notes / materials / knowledge / refs fallback
 - [ハーネス層](docs/layers/harness.md) — Agent instructions / skills / rules
 - [Upstream 連携層](docs/layers/upstream.md) — local patch / feedback / PR
 - [Project health check](docs/project-health.md) — `runo lint` による検査

--- a/docs/agent-user-guide.md
+++ b/docs/agent-user-guide.md
@@ -18,6 +18,7 @@ project 側では `.runops/knowledge/runops/agent-user-guide.md` と
 |------|---------|
 | version 確認 | `runo --version` |
 | プロジェクト状況把握 | `runo context --json` (`research_agenda` / latest note を含む) |
+| 推奨 plugin metadata 確認 | `runo plugins --check` / `runo plugins --json` |
 | project health check | `runo lint --scope structure,analysis,knowledge,plugins` |
 | case テンプレート生成 | `runo case new <name>` |
 | 最小 case テンプレート生成 | `runo case new <name> --minimal` |
@@ -178,7 +179,7 @@ completed → archived → purged
 | source material | `materials/` | 設計・読解・解析時 |
 | 構造化 fact (制約・依存性) | `.runops/facts.toml` | 必要な場合のパラメータ設計・検証時 |
 | 実験知見 (Markdown) | `.runops/insights/` | 必要な場合の作業開始時・解析後 |
-| シミュレータドキュメント | simulator/environment plugin, `.runops/knowledge/`, 任意の `refs/` mirror | パラメータ設計時 |
+| シミュレータドキュメント | simulator/environment plugin, `runo plugins --json` の `delegated_capabilities`, `.runops/knowledge/`, 任意の `refs/` fallback mirror | パラメータ設計時 |
 | 実行環境 | `.runops/environment.toml` | job 設定・launcher 選択時 |
 | 外部共有知識 | `refs/knowledge/` | 必要に応じて |
 
@@ -205,7 +206,8 @@ runo knowledge add-fact "<claim>" -t <type> -s <simulator> -c <confidence>
 
 ## Simulator Adapter のガイド
 
-各シミュレータ固有のガイドは、まず simulator/environment plugin と
+各シミュレータ固有のガイドは、まず `runo plugins --json` の
+`delegated_capabilities` で委譲先 plugin を確認し、simulator/environment plugin と
 `.runops/knowledge/enabled/imports.md` を参照する。`runo init --with-refs` などで
 `refs/<repo>/docs/agent-*.md` が存在する場合は、ローカル mirror の fallback として
 参照する。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -631,7 +631,8 @@ CLI 層で `SimctlError` をキャッチし、ユーザーフレンドリーな�
 ## 知識層 (Knowledge Layer)
 
 AI エージェントがシミュレーションを自律的に実行するための知識管理アーキテクチャ。
-3 つのドメインで構成される:
+現行の Knowledge Layer は、シミュレータ知識、実行環境知識、研究意図、
+実験知見、lab notebook / materials などの見える作業場を分けて扱う。
 
 ### シミュレータ知識
 
@@ -651,7 +652,8 @@ adapter.required_outputs() ← analysis-ready に必要な成果物
 - `codex_plugins()`: simulator に推奨する外部 Codex plugin の導入導線と委譲役割 (`capabilities`)
 - `runo plugins`: project / simulator / site から推薦 plugin を再表示・JSON 出力し、推薦メタデータを検査する監査入口
 - `runo doctor`: 推薦メタデータの error も project 健全性として検出するが、plugin の install 状態は管理しない
-- `refs/`: `runo init --with-refs` または手動 clone で使う任意のローカル mirror
+- `runo lint --scope plugins`: plugin 推薦 metadata と委譲 role index を project health check として検査する
+- `refs/`: `runo init --with-refs` または手動 clone で使う任意のローカル fallback mirror
 - `doc_repos()` / `knowledge_sources()`: 任意 mirror を使う場合の clone 先とインデックス対象
 - `parameter_schema()`: 型・単位・範囲・制約・導出公式
 - `validate_params()`: CFL 条件、Debye 長解像度など

--- a/docs/get-started-with-agent.md
+++ b/docs/get-started-with-agent.md
@@ -29,9 +29,11 @@ runops は plugin を自動 install せず、
 メタデータの欠落を検査しますが、user-local な plugin install 状態は検査しません。
 
 ベース入力ファイル (`plasma.toml`, `beach.toml` など) を明示すると意図が伝わりやすくなります。
-一方で、まだベースを決めていない場合でも、Agent は simulator/environment plugin、
-`.runops/knowledge/enabled/imports.md`、`materials/`、任意の `refs/` mirror にある
-docs/cookbook を順に確認し、入力例や推奨パラメータをもとに case の叩き台を作れます。
+一方で、まだベースを決めていない場合でも、Agent は `runo plugins --json` の
+`delegated_capabilities` から simulator/environment plugin を確認し、
+`.runops/knowledge/enabled/imports.md`、`materials/` を読んで case の叩き台を作れます。
+任意の `refs/` mirror にある docs/cookbook は、plugin や明示的 knowledge source が
+使えない場合の fallback として参照します。
 
 あとはエージェントが campaign 設計、case 作成、survey 展開、run 生成・投入・解析・知見整理を進めます。
 人間が CLI の全体を覚える必要はありません。

--- a/docs/layers/README.md
+++ b/docs/layers/README.md
@@ -31,7 +31,7 @@ Experiment / Execution / Analysis / Research / Knowledge の各 Layer にある�
 | Execution Kernel | [execution-kernel.md](execution-kernel.md) | run / submit / sync / manifest / provenance の実行状態正本 |
 | Analysis Layer | [analysis.md](analysis.md) | 解析・可視化成果物、summary、survey 集計、cross-run 比較 |
 | Research Layer | [research.md](research.md) | `research/agenda.md` による現在判断の台帳 |
-| Knowledge Layer | [knowledge.md](knowledge.md) | Agent が再利用する知識、notes、materials、`.runops/insights/` |
+| Knowledge Layer | [knowledge.md](knowledge.md) | Agent が再利用する plugin 導線、notes、materials、`.runops/insights/`、refs fallback |
 | Harness Layer | [harness.md](harness.md) | Agent の手順、権限、skills、rules、project-local harness |
 | Upstream Integration Layer | [upstream.md](upstream.md) | runops local patch、feedback issue、PR、update / migration の境界 |
 

--- a/docs/layers/harness.md
+++ b/docs/layers/harness.md
@@ -73,10 +73,11 @@ Harness Layer に置くもの:
 
 1. project root の `AGENTS.md` / `CLAUDE.md`
 2. directory-specific `AGENTS.md` / `CLAUDE.md`
-3. relevant skill
-4. relevant layer doc under `docs/layers/`
-5. `.runops/knowledge/enabled/imports.md` と `.runops/knowledge/runops/`
-6. 実行中 package の場所 (`uvx --from runops python -c "import runops; print(runops.__file__)"`) は最後の手段
+3. `runo plugins --json` の `delegated_capabilities` と該当 simulator/environment plugin skill
+4. relevant project-local skill
+5. relevant layer doc under `docs/layers/`
+6. `.runops/knowledge/enabled/imports.md` と `.runops/knowledge/runops/`
+7. 実行中 package の場所 (`uvx --from runops python -c "import runops; print(runops.__file__)"`) は最後の手段
 
 ## 他レイヤとの関係
 

--- a/docs/layers/interface.md
+++ b/docs/layers/interface.md
@@ -66,6 +66,7 @@ drift を早期に検出します。
 ```bash
 uvx --from runops runo init
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 既存 project:
@@ -74,6 +75,7 @@ uvx --from runops runo doctor
 uvx --from runops runo setup https://github.com/user/my-project.git
 cd my-project
 uvx --from runops runo doctor
+uvx --from runops runo plugins --check
 ```
 
 ここまで終わったら、CLI を順番に叩くのではなく Agent に研究内容を渡します。
@@ -94,17 +96,21 @@ uvx --from runops runo doctor
 | `runo doctor [PATH]` | 環境検査。設定、sbatch、run_id 一意性、環境検出、推奨 plugin metadata を確認 |
 | `runo context [DIR]` | Agent 向け project context の要約を表示 |
 | `runo context --json` | Agent 向け context を JSON で取得 |
+| `runo plugins [DIR] [--json] [--check] [--strict]` | project / simulator / site 由来の推奨 Codex plugin inventory を表示・検査 |
 | `runo lint [PATH] [--scope ...] [--json]` | project state と推奨 plugin metadata の health check |
 | `runo migrate list/show/apply` | project-state migration を確認・適用 |
 | `runo config show` | 設定表示 |
 | `runo config add-simulator` | シミュレータ追加 |
 | `runo config add-launcher` | ランチャー追加 |
 | `runo update` | シミュレータパッケージのアップグレード |
-| `runo update-harness --plan/apply-chain` | project 側 Agent harness / managed scaffold を versioned chain で再生成 |
+| `runo update-harness [--plan] [--apply-chain]` | project 側 Agent harness / managed scaffold を versioned chain で再生成 |
 | `runo update-refs [SIMS...]` | 任意 refs mirror 更新 + knowledge index 再生成 |
 | `runo mcp serve --transport stdio` | local MCP provider を stdio で起動 |
 | `runo mcp serve --transport streamable-http` | local MCP provider を HTTP で起動 |
 | `runo mcp check` | MCP tool registry / safety contract の軽量検査 |
+| `runo mcp tools --json` | MCP tool metadata を JSON で表示 |
+| `runo mcp resources --json` | MCP resources metadata を JSON で表示 (現状は空) |
+| `runo mcp prompts --json` | MCP prompts metadata を JSON で表示 (現状は空) |
 
 MCP provider は Agent / host 向けの edge interface です。read / inspect / plan tool
 だけを初期公開し、submit / cancel / delete などの external / destructive tool は

--- a/docs/layers/knowledge.md
+++ b/docs/layers/knowledge.md
@@ -4,11 +4,11 @@ AI エージェントがシミュレーション実行・解析を自律的に�
 
 ## 概要
 
-runops の知識層は 4 つのドメインで構成される:
+runops の知識層は 5 つのドメインで構成される:
 
 | ドメイン | 内容 | 管理場所 | 更新契機 |
 |----------|------|----------|---------|
-| **シミュレータ知識** | パラメータスキーマ、物理的制約、安定性条件、長文 Agent context | simulator/environment plugin, Adapter metadata, `.runops/knowledge/`, 任意の `refs/` mirror | plugin install/update, Adapter 更新, `runo update-refs` (任意 mirror) |
+| **シミュレータ知識** | パラメータスキーマ、物理的制約、安定性条件、長文 Agent context | simulator/environment plugin, Adapter metadata, `.runops/knowledge/`, 任意の `refs/` fallback mirror | plugin install/update, Adapter 更新, `runo update-refs` (任意 mirror) |
 | **外部共有知識** | ラボ共通の解析手法・知識、シミュレータ汎用知識 | `refs/knowledge/` | `runo knowledge source sync` |
 | **実行環境知識** | クラスタ構成、パーティション、モジュール | `.runops/environment.toml` | `runo doctor` |
 | **研究意図** | 仮説、実験設計、変数定義、観測量 | `campaign.toml` | ユーザーが記述 |
@@ -45,7 +45,7 @@ project/
     agenda.md
     proposals/                   # 高コスト・方向転換前の任意 proposal
     reviews/                     # agenda checkpoint の snapshot
-  refs/                          # 任意のローカル mirror / 外部知識 mount
+  refs/                          # 任意の fallback mirror / 外部知識 mount
     MPIEMSES3D/
       cookbook/                   # simulator cookbook (入力例・設定カタログ)
         COOKBOOK.md
@@ -309,11 +309,13 @@ mirror として扱う。
 
 Agent の利用順序:
 
-1. `cookbook/COOKBOOK.md` で概要を把握
-2. `cookbook/index.toml` で候補を選ぶ
-3. 各 entry の `meta.toml` で用途と適用条件を確認
-4. `input.toml` / `fragment.toml` の実ファイルを読む
-5. `README.md` で注意事項を確認
+1. `runo plugins --json` の `delegated_capabilities["cookbook"]` で委譲先 plugin を確認
+2. simulator/environment plugin skill、または明示的 knowledge source の cookbook guide を読む
+3. plugin / knowledge source が使えず `refs/` mirror がある場合だけ、fallback として `cookbook/COOKBOOK.md` で概要を把握
+4. `cookbook/index.toml` で候補を選ぶ
+5. 各 entry の `meta.toml` で用途と適用条件を確認
+6. `input.toml` / `fragment.toml` の実ファイルを読む
+7. `README.md` で注意事項を確認
 
 制約チェックは runops Adapter の `validate_params()` が担当する。
 cookbook は「何をどう使うか」に集中する。
@@ -407,13 +409,14 @@ repo/
 
 `entrypoints.toml` がある場合、`render_imports()` はそこに列挙された `imports` / `profiles.<name>.imports` だけを `imports.md` に載せる。manifest に無い profile は `profiles/<name>.md` へフォールバックする。`validate_source_structure()` は `entrypoints.toml` の parse、参照先ファイル、profile 内 `@...` import、`analysis/observables/*.toml` と `analysis/recipes/*.toml` も検査する。
 
-### CLAUDE.md 連携
+### Agent harness 連携
 
 `runo knowledge source render` が `.runops/knowledge/enabled/imports.md` を生成する。
-このファイルは有効な profile への `@import` 参照を含み、
-project の `CLAUDE.md` から `@.runops/knowledge/enabled/imports.md` で一括参照できる。
+このファイルは有効な profile への参照を含む。Claude Code では project の
+`CLAUDE.md` から `@.runops/knowledge/enabled/imports.md` で一括参照できる。
+Codex では `AGENTS.md` / project-local skill が同じ path を読む導線を持つ。
 
-`runo init` 時に CLAUDE.md テンプレートに自動挿入される。
+`runo init` 時に project harness テンプレートへ自動挿入される。
 
 ### init / setup での動作
 

--- a/docs/simulator-kb-spec.md
+++ b/docs/simulator-kb-spec.md
@@ -1,7 +1,13 @@
 # Simulator Cookbook Spec (v0.2)
 
-シミュレーションリポジトリ側で、AI Agent や管理ツールが参照できる
+simulator 側の plugin / knowledge source / 任意 mirror が、AI Agent や管理ツールに
 ツール非依存の入力例・設定カタログを提供するための規約。
+
+plugin-first な運用では、cookbook の本文と長文 workflow は simulator 側 Codex plugin
+または明示的 knowledge source が提供する。runops 本体は cookbook 本文を内包せず、
+`runo plugins --json` の `delegated_capabilities["cookbook"]` と推薦 metadata で
+委譲先を案内する。`refs/` は offline 利用、private repo、開発中 checkout を近くに
+置くための fallback mirror として扱う。
 
 ## 目的
 
@@ -23,7 +29,7 @@
 ## ディレクトリ構成
 
 ```text
-repo/
+provider-repo/
   cookbook/
     COOKBOOK.md              # 管理ガイド (人間・保守 Agent 向け)
     index.toml              # discovery 用目録
@@ -59,10 +65,12 @@ repo/
 
 ### Agent / ツール
 
-1. `index.toml` で全 entry を一覧し、`tags` / `recommended_for` / `status` で候補を絞る
-2. 候補 entry の `meta.toml` で詳細を確認
-3. `input.toml` / `fragment.toml` の実ファイルを読む
-4. 必要なら `README.md` で注意事項を確認
+1. runops project では `runo plugins --json` の `delegated_capabilities["cookbook"]` で委譲先を確認する
+2. simulator/environment plugin、または明示的 knowledge source が提供する cookbook guide を読む
+3. raw cookbook tree を直接読む場合は `index.toml` で全 entry を一覧し、`tags` / `recommended_for` / `status` で候補を絞る
+4. 候補 entry の `meta.toml` で詳細を確認
+5. `input.toml` / `fragment.toml` の実ファイルを読む
+6. 必要なら `README.md` で注意事項を確認
 
 ### 人間 / 保守者
 
@@ -414,7 +422,8 @@ cookbook は「何をどう使うか」だけに集中する。
 
 ## COOKBOOK.md テンプレート
 
-以下は simulator repo の `cookbook/COOKBOOK.md` に置くテンプレート。
+以下は simulator repo、simulator plugin の context repository、または明示的
+knowledge source の `cookbook/COOKBOOK.md` に置くテンプレート。
 `{...}` はリポジトリに合わせて書き換える。
 
 ````markdown
@@ -437,10 +446,11 @@ cookbook/
 
 ### Agent / ツール
 
-1. `index.toml` を読んで、`tags` / `recommended_for` / `status` で候補を絞る
-2. 候補 entry の `meta.toml` で用途と適用条件を確認する
-3. `input.toml` (または `fragment.toml`) を読む
-4. 必要なら `README.md` で注意事項を確認する
+1. plugin / knowledge source の guide でこの cookbook の位置づけを確認する
+2. `index.toml` を読んで、`tags` / `recommended_for` / `status` で候補を絞る
+3. 候補 entry の `meta.toml` で用途と適用条件を確認する
+4. `input.toml` (または `fragment.toml`) を読む
+5. 必要なら `README.md` で注意事項を確認する
 
 ### 人間
 

--- a/src/runops/templates/knowledge/runops/agent-user-guide.md
+++ b/src/runops/templates/knowledge/runops/agent-user-guide.md
@@ -18,11 +18,12 @@ project-local skill を参照する。
 ## 最初に読むもの
 
 1. `uvx --from runops runo context --json`
-2. `campaign.toml`
-3. `research/agenda.md`
-4. 関連する `cases/**/case.toml` と `runs/**/survey.toml`
-5. `.runops/facts.toml` と `.runops/knowledge/candidates/facts/`
-6. 必要なら `runo runs status` / `runo runs log -e`
+2. `uvx --from runops runo plugins --check` と `uvx --from runops runo plugins --json`
+3. `campaign.toml`
+4. `research/agenda.md`
+5. 関連する `cases/**/case.toml` と `runs/**/survey.toml`
+6. `.runops/facts.toml` と `.runops/knowledge/candidates/facts/`
+7. 必要なら `runo runs status` / `runo runs log -e`
 
 ## 知識と記録
 
@@ -30,6 +31,8 @@ project-local skill を参照する。
 - 現在の高レベルな研究判断は `research/agenda.md` に残す
 - 整理済み知見は `runo knowledge save` / `runo knowledge add-fact` を使う
 - `.runops/knowledge/` は生成済み Agent context であり、手で整形しない
+- simulator cookbook や長文 workflow は推奨 Codex plugin / explicit knowledge
+  source を優先し、`refs/` mirror は存在する場合だけ fallback として使う
 
 ## runops 自体の確認
 

--- a/src/runops/templates/scaffold/notes/README.md
+++ b/src/runops/templates/scaffold/notes/README.md
@@ -5,8 +5,8 @@
 `materials/` に置きます。現在の高レベルな研究判断は `research/agenda.md` に
 置きます。
 
-`.runops/knowledge/` は simulator/environment plugin、任意の `refs/` mirror、
-`runo knowledge source render` などから生成する Agent context です。
+`.runops/knowledge/` は simulator/environment plugin、明示的 knowledge source、
+任意の `refs/` fallback mirror などから生成する Agent context です。
 `.runops/insights/` と `.runops/facts.toml` は
 互換性のため残る advanced/structured knowledge store と考え、日常のメモや
 レポートはまず `notes/`, `materials/`, `research/` に置くのを推奨します。

--- a/src/runops/templates/skills/runops-reference/SKILL.md
+++ b/src/runops/templates/skills/runops-reference/SKILL.md
@@ -16,6 +16,8 @@ project 側で実行するときの標準形は `uvx --from runops runo <command
 
 ```bash
 runo context --json      # project / campaign / runs / failures の概要
+runo plugins --check     # 推薦 plugin metadata と導入状態を確認
+runo plugins --json      # delegated_capabilities を含む plugin payload
 runo lint                # project state の health check
 runo lint --scope structure,analysis,knowledge,plugins
 runo runs list           # run 一覧


### PR DESCRIPTION
## Summary
- Document plugin-first delegation for simulator cookbook and long-form simulator workflows.
- Clarify that `refs/` is an optional fallback mirror rather than the primary simulator knowledge path.
- Update README, layer docs, agent guides, harness rules, and project-side templates to include `runo plugins --check` / `runo plugins --json` guidance and current MCP/update-harness commands.

## Validation
- `git diff --check`
- `tssrun -p eb uv run pytest tests/test_cli/test_plugins.py tests/test_cli/test_mcp.py tests/test_harness -q` (37 passed)
- `tssrun -p eb uv run pytest tests/test_core/test_plugins.py tests/test_core/test_context.py tests/test_mcp -q` (72 passed)
