### PR TITLE
[codex] feat: add setup plugins project skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Agent は確認前に、対象 run、queue、資源量、想定 core-hour、変�
 uvx --from runops runo init
 uvx --from runops runo doctor
 uvx --from runops runo plugins --check
+# Codex: $setup-plugins
+# Claude Code: /setup-plugins
 ```
 
 既存 project:
@@ -143,6 +145,8 @@ uvx --from runops runo setup https://github.com/user/my-project.git
 cd my-project
 uvx --from runops runo doctor
 uvx --from runops runo plugins --check
+# Codex: $setup-plugins
+# Claude Code: /setup-plugins
 ```
 
 ここまで終わったら、CLI を順に叩くのではなく Agent に研究内容を渡します。

--- a/docs/agent-user-guide.md
+++ b/docs/agent-user-guide.md
@@ -19,6 +19,7 @@ project 側では `.runops/knowledge/runops/agent-user-guide.md` と
 | version 確認 | `runo --version` |
 | プロジェクト状況把握 | `runo context --json` (`research_agenda` / latest note を含む) |
 | 推奨 plugin metadata 確認 | `runo plugins --check` / `runo plugins --json` |
+| 推奨 plugin 導入補助 | Codex: `$setup-plugins` / Claude Code: `/setup-plugins` |
 | project health check | `runo lint --scope structure,analysis,knowledge,plugins` |
 | case テンプレート生成 | `runo case new <name>` |
 | 最小 case テンプレート生成 | `runo case new <name> --minimal` |
@@ -138,8 +139,10 @@ runo notes show latest | head -100
 
 ## ハーネスのガード
 
-`runo init` は `.claude/settings.json` と `.claude/hooks/` も生成し、
-Claude Code 向けに project 内の保護ルールを設定する。
+`runo init` は `.claude/settings.json` と `.claude/rules/` を生成し、
+Claude Code 向けに project 内の保護ルールを設定する。PreToolUse hook script は
+既定では生成しない。plugin が hook を提供する場合だけ、その plugin の手順に従って
+別途有効化する。
 
 - 直接編集してよいのは主に `campaign.toml`、`cases/**`、`runs/**/survey.toml`、通常の docs
 - 直接編集してはいけないのは `runs/**/manifest.toml`、`input/**`、`submit/**`、`work/**`、`SITE.md`

--- a/docs/get-started-with-agent.md
+++ b/docs/get-started-with-agent.md
@@ -24,6 +24,9 @@ KUDPC HPC plugin、`beach` では BEACH Context plugin が案内されます。
 解析 workflow や handoff plugin も生成 harness に反映できます。
 runops は plugin を自動 install せず、
 ユーザーの Codex 環境で `/plugins` や `codex plugin ...` により有効化します。
+生成済み project では、Codex なら `$setup-plugins`、Claude Code なら
+`/setup-plugins` を使うと、Agent が `install_hint` / `activation_hint` を読み、
+可能な範囲で install / enable / plugin-provided hook 導線を整えます。
 既存 project で推薦を確認したい場合は `runo plugins`、agent や外部 tool から
 読む場合は `runo plugins --json` を使います。`runo plugins --check` は推薦
 メタデータの欠落を検査しますが、user-local な plugin install 状態は検査しません。
@@ -46,6 +49,8 @@ runops は plugin を自動 install せず、
 uvx --from runops runo init
 uvx --from runops runo doctor
 uvx --from runops runo plugins --check
+# Codex: $setup-plugins
+# Claude Code: /setup-plugins
 ```
 
 既存プロジェクトをセットアップする場合:
@@ -55,6 +60,8 @@ uvx --from runops runo setup https://github.com/user/my-project.git
 cd my-project
 uvx --from runops runo doctor
 uvx --from runops runo plugins --check
+# Codex: $setup-plugins
+# Claude Code: /setup-plugins
 ```
 
 `runo init` がディレクトリ構造と初期ファイルを作ります。
@@ -68,6 +75,9 @@ Experiment Layer の `campaign.toml`・`case.toml`・`survey.toml` と、
 Execution Kernel の `manifest.toml` がそれぞれ何の役割を持つか掴みやすくなります。
 
 ## 最初の依頼の出し方
+
+`setup-plugins` は推奨 plugin と plugin-provided hook 導線を整えるための任意ステップです。
+plugin が整ったら、次に `setup-runops` で project の聞き取りへ進みます。
 
 `setup-runops` は、**`runo init` / `runo setup` が終わった後**に使う
 開始時の聞き取り用 SKILL です。最初のプロンプトでは、細かい TOML や CLI

--- a/src/runops/templates/harness/shared/partials/agent-body.md.j2
+++ b/src/runops/templates/harness/shared/partials/agent-body.md.j2
@@ -31,6 +31,7 @@ campaign 設計、case / survey 編集、run 生成、投入、監視、解析�
 |---|---|
 | `{{ skill_prefix }}new-case` | ケースを作成・編集する |
 | `{{ skill_prefix }}setup-runops` | project の初期セットアップと最初の聞き取り |
+| `{{ skill_prefix }}setup-plugins` | 推奨 Codex plugin の install / enable / plugin-provided hook 導線を整える |
 | `{{ skill_prefix }}create-run` | Run / Survey を生成する |
 | `{{ skill_prefix }}survey-design` | パラメータサーベイを設計する |
 | `{{ skill_prefix }}run-all` | survey の全 run を生成して投入する |

--- a/src/runops/templates/knowledge/runops/agent-user-guide.md
+++ b/src/runops/templates/knowledge/runops/agent-user-guide.md
@@ -33,6 +33,8 @@ project-local skill を参照する。
 - `.runops/knowledge/` は生成済み Agent context であり、手で整形しない
 - simulator cookbook や長文 workflow は推奨 Codex plugin / explicit knowledge
   source を優先し、`refs/` mirror は存在する場合だけ fallback として使う
+- 推奨 plugin の install / enable / plugin-provided hook 導線を整える必要があれば
+  `{{ skill_prefix }}setup-plugins` を使う
 
 ## runops 自体の確認
 

--- a/src/runops/templates/skills/setup-plugins/SKILL.md
+++ b/src/runops/templates/skills/setup-plugins/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: setup-plugins
+description: Install, activate, or verify Codex plugins recommended by a generated runops project. Use after runo init/setup/update-harness, or when the user asks to set up simulator/site plugins, plugin activation, or plugin-provided Codex hooks for the project.
+---
+
+# 推奨 Codex plugins をセットアップする
+
+runops project が持つ推奨 plugin metadata を読み、必要な Codex plugin の
+install / enable / activation / plugin-provided hook 導線を整える。
+
+runops 本体は user-local な Codex plugin 状態を管理しない。この skill は Agent が
+その作業を代行・補助するための入口であり、project 側 metadata と plugin 側手順を
+正本として扱う。
+
+## 安全原則
+
+- まず `runo plugins --check` と `runo plugins --json` を読む。
+- `install_hint` / `activation_hint` / plugin 側 README なしに、独自の install 手順を
+  作らない。
+- `~/.codex/**`, `$CODEX_HOME/**`, plugin cache、user-local marketplace、hook 設定など
+  project 外の状態を変更する前に、変更対象、理由、実行コマンド、戻し方を短く示す。
+- token、private repo URL、認証情報をログや note に残さない。
+- `curl | sh`、`bash <(curl ...)`、`git reset --hard`、`rm -rf` などを install 手順として
+  実行しない。plugin 側が要求していても、ユーザー確認と代替案の提示を挟む。
+- Codex hooks は experimental。plugin が hook を提供している場合だけ、その公式手順に
+  従って有効化する。runops project 側で hook を自作しない。
+
+## まず確認すること
+
+project root で実行する:
+
+```bash
+pwd
+uvx --from runops runo plugins --check
+uvx --from runops runo plugins --json
+```
+
+必要に応じて project context も読む:
+
+```bash
+uvx --from runops runo context --json
+```
+
+`plugins --check` が metadata error を返す場合は、plugin install へ進む前に
+project 側の `runops.toml` / simulator config / site profile の推薦 metadata を直す。
+warning だけなら、内容を説明したうえで続行してよい。
+
+## 判断すること
+
+`runo plugins --json` から次を整理する:
+
+- `recommendations[].name` / `display_name`
+- `recommendations[].visibility`
+- `recommendations[].sources`
+- `recommendations[].capabilities`
+- `recommendations[].install_hint`
+- `recommendations[].activation_hint`
+- `delegated_capabilities`
+- `management.runops_installs_plugins` と `management.runops_enables_plugins`
+
+`delegated_capabilities` を見て、作業に必要な role を優先する。例:
+
+- `parameter-design`, `input-review`, `cookbook`
+- `run-diagnose`, `output-analysis`, `visualization`
+- `site-runbook`, `hpc-workflow`
+
+## install / enable の進め方
+
+### 1. exact command がある場合
+
+`install_hint` に `codex plugin ...`、marketplace 登録、private plugin checkout などの
+具体的なコマンドがある場合:
+
+1. そのコマンドが現在の環境で使えるか確認する (`command -v codex` など)。
+2. 実行対象が project 外なら、変更先と理由を示す。
+3. ユーザーがこの skill で install / enable を依頼している場合は、危険な command でなければ実行する。
+4. 実行後に `activation_hint` に従い、必要なら「新しい Codex thread を開始」などの残作業を報告する。
+
+### 2. `/plugins` など UI 操作が必要な場合
+
+Agent が現在の環境から plugin manager を操作できる場合は、その公式経路を使う。
+操作できない場合は、plugin 名、表示名、capability、install/activation 手順を
+短くまとめ、ユーザーが `/plugins` で選ぶべき項目を明示する。
+
+### 3. private-or-gated plugin の場合
+
+`visibility = "private-or-gated"` の plugin は、認証やローカル marketplace が必要な
+ことがある。
+
+- 認証状態は最小限だけ確認する。token は表示しない。
+- private repo を clone する場合は、`install_hint` に書かれた sparse checkout などの
+  低コスト手順を優先する。
+- 権限不足なら、代替として project-local skill、明示的 knowledge source、
+  `refs/` fallback mirror のどれを使うか提案する。
+
+## plugin-provided hooks の扱い
+
+ここで扱う hooks は、**plugin が明示的に提供する hook manifest / installer /
+activation 手順**に限る。runops project の都合で Agent が独自 hook を設計する入口ではない。
+
+1. `capabilities`、`install_hint`、`activation_hint`、plugin README から、
+   plugin が hooks を提供しているか確認する。
+2. plugin が提供する installer / enable command / hook manifest がある場合だけ使う。
+   公式導線が無ければ hook は有効化しない。
+3. `.codex/hooks.json` など project-local hook file を作る場合は、plugin が提供する
+   template / manifest / command に基づく。hook の内容、発火条件、失敗時の影響、
+   無効化方法を提示してから書く。
+4. user-local plugin cache や marketplace に hook を登録する場合も、plugin の
+   documented command を優先し、変更先を先に示す。
+5. `~/.codex/config.toml` の `[features].codex_hooks = true` など user-local config は、
+   ユーザー確認なしに編集しない。必要なら追記内容だけ提示する。
+
+runops の既定は hooks なし。plugin が hooks を提供しない場合、submit / delete /
+destructive command の扱いは `.codex/rules/runops.rules` と human gate で制御する。
+
+## 検証
+
+install / enable / plugin-provided hook 設定のあと、できる範囲で確認する:
+
+```bash
+uvx --from runops runo plugins --check
+uvx --from runops runo plugins --json
+```
+
+注意: `runo plugins --check` は project が持つ推薦 metadata の検査であり、
+user-local plugin が本当に読み込まれたかまでは保証しない。
+plugin を有効化したあとに新しい Codex thread が必要な場合は、そこで再確認する。
+
+## 完了報告
+
+最後に次を短く報告する:
+
+- install / enable 済みの plugin
+- まだユーザー操作が必要な plugin
+- plugin-provided hook を有効化したか、しなかった理由
+- 新しい thread / Codex restart が必要か
+- `delegated_capabilities` 上、どの role がどの plugin に委譲されるか
+
+plugin が整ったら `{{ skill_prefix }}setup-runops` に戻り、campaign / case / survey の
+初期設計へ進む。

--- a/src/runops/templates/skills/setup-runops/SKILL.md
+++ b/src/runops/templates/skills/setup-runops/SKILL.md
@@ -59,6 +59,9 @@ uvx --from runops runo doctor
 uvx --from runops runo plugins --check
 ```
 
+推奨 plugin の導入・有効化・plugin-provided hook 設定まで整える必要がある場合は、
+`{{ skill_prefix }}setup-plugins` を使ってから campaign / case 設計へ進む。
+
 `runops.toml` が見つからない場合は、まず cwd が project root から外れていないか確認する。
 `uvx` が使えない、`.venv/` が壊れているなど実行環境の問題なら、短く状況を説明して
 `{{ skill_prefix }}setup-env` の内容に従って環境を修復する。
@@ -103,10 +106,11 @@ submit はまだしない。
 1. `uvx --from runops runo context --no-json` と
    `uvx --from runops runo doctor`、`uvx --from runops runo plugins --check`
    で project の現在状態を読む
-2. simulator / site / launcher の不足があれば修復方針を出す
-3. `{{ skill_prefix }}setup-campaign` / `{{ skill_prefix }}new-case` /
+2. 推奨 plugin / plugin-provided hooks の準備が必要なら `{{ skill_prefix }}setup-plugins` を使う
+3. simulator / site / launcher の不足があれば修復方針を出す
+4. `{{ skill_prefix }}setup-campaign` / `{{ skill_prefix }}new-case` /
    `{{ skill_prefix }}survey-design` を必要に応じて使う
-4. submit はしない
+5. submit はしない
 
 ## project として動かない場合
 
@@ -156,11 +160,12 @@ bootstrap が終わったら、この skill の主経路に戻り、project の�
 1. 現在の状態を短く要約する: project root、simulator、doctor 結果、未設定項目
 2. init / setup で生成された scaffold が未 commit なら、研究作業に入る前に
    baseline commit を提案する
-3. 研究テーマがあるなら `{{ skill_prefix }}setup-campaign` で `campaign.toml` を整える
-4. base input があるなら `{{ skill_prefix }}new-case` で case を作る
-5. independent variables が見えているなら `{{ skill_prefix }}survey-design` で survey を作る
-6. run 生成や submit は、対象・資源・確認条件を示してから進める
-7. runops 自体の不満点や改善案が出たら、`{{ skill_prefix }}feedback-runops`
+3. 推奨 plugin / plugin-provided hooks の準備が残っていれば `{{ skill_prefix }}setup-plugins` で整える
+4. 研究テーマがあるなら `{{ skill_prefix }}setup-campaign` で `campaign.toml` を整える
+5. base input があるなら `{{ skill_prefix }}new-case` で case を作る
+6. independent variables が見えているなら `{{ skill_prefix }}survey-design` で survey を作る
+7. run 生成や submit は、対象・資源・確認条件を示してから進める
+8. runops 自体の不満点や改善案が出たら、`{{ skill_prefix }}feedback-runops`
    で候補一覧、`{{ skill_prefix }}feedback-runops 不満点・改善案` で
    HarnessOps record と issue 下書きを作る
 
@@ -179,6 +184,7 @@ git commit -m "chore: scaffold runops project"
 ```text
 次はこの順で進めるとよいです。
 - campaign.toml を研究テーマから整理して。
+- {{ skill_prefix }}setup-plugins 推奨 plugin と plugin-provided hooks の導入状態を整えて。
 - この入力ファイルをベースに case を作って。
 - 照射角を振る survey.toml を作って。submit はまだしない。
 - {{ skill_prefix }}feedback-runops setup 中に気になった改善点
@@ -197,6 +203,7 @@ project で `runo notes append` が使えるなら、準備段階の判断を
 ## 完了条件
 
 - `runo doctor` と `runo plugins --check` の結果を確認した
+- 必要な場合は `{{ skill_prefix }}setup-plugins` で plugin / plugin-provided hook 導線を整理した
 - project root と次に編集すべきファイルが明確
 - campaign / case / survey / run 生成のどこまで進めたかを説明した
 - init / setup 生成物の baseline commit が必要かどうかを案内した

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -507,6 +507,7 @@ class TestInit:
         codex_skills_dir = tmp_path / ".agents" / "skills"
         assert (skills_dir / "setup-env" / "SKILL.md").exists()
         assert (skills_dir / "setup-runops" / "SKILL.md").exists()
+        assert (skills_dir / "setup-plugins" / "SKILL.md").exists()
         assert (skills_dir / "survey-design" / "SKILL.md").exists()
         assert (skills_dir / "check-status" / "SKILL.md").exists()
         assert (skills_dir / "analyze" / "SKILL.md").exists()
@@ -514,6 +515,7 @@ class TestInit:
         assert (skills_dir / "runops-reference" / "SKILL.md").exists()
         assert (codex_skills_dir / "setup-env" / "SKILL.md").exists()
         assert (codex_skills_dir / "setup-runops" / "SKILL.md").exists()
+        assert (codex_skills_dir / "setup-plugins" / "SKILL.md").exists()
         assert (codex_skills_dir / "summarize-script" / "SKILL.md").exists()
         assert (codex_skills_dir / "runops-reference" / "SKILL.md").exists()
         setup_content = (skills_dir / "setup-env" / "SKILL.md").read_text(
@@ -524,6 +526,7 @@ class TestInit:
             codex_skills_dir / "setup-runops" / "SKILL.md"
         ).read_text(encoding="utf-8")
         assert "$setup-env" in setup_runops_content
+        assert "$setup-plugins" in setup_runops_content
         assert "$setup-campaign" in setup_runops_content
         assert "project は生成済み" in setup_runops_content
         assert "状態確認だけで応答を終えない" in setup_runops_content
@@ -532,6 +535,16 @@ class TestInit:
         assert 'git commit -m "chore: scaffold runops project"' in setup_runops_content
         assert "次に頼みやすい形で 2-4 個" in setup_runops_content
         assert "{{ skill_prefix }}" not in setup_runops_content
+        setup_plugins_content = (
+            codex_skills_dir / "setup-plugins" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert "runo plugins --check" in setup_plugins_content
+        assert "runo plugins --json" in setup_plugins_content
+        assert "Codex hooks は experimental" in setup_plugins_content
+        assert "plugin-provided hook" in setup_plugins_content
+        assert "runops project 側で hook を自作しない" in setup_plugins_content
+        assert "$setup-runops" in setup_plugins_content
+        assert "{{ skill_prefix }}" not in setup_plugins_content
         analyze_content = (skills_dir / "analyze" / "SKILL.md").read_text(
             encoding="utf-8"
         )

--- a/tests/test_cli/test_update_harness.py
+++ b/tests/test_cli/test_update_harness.py
@@ -173,6 +173,7 @@ class TestUpdateHarnessBasic:
         assert ".codex/config.toml" in lock
         assert ".codex/rules/runops.rules" in lock
         assert ".agents/skills/new-case/SKILL.md" in lock
+        assert ".agents/skills/setup-plugins/SKILL.md" in lock
         assert ".agents/skills/patch-runops/SKILL.md" in lock
         assert ".agents/skills/python-package-refactor/SKILL.md" in lock
         assert (

--- a/tests/test_harness/test_codex.py
+++ b/tests/test_harness/test_codex.py
@@ -97,6 +97,7 @@ def test_bundle_emits_codex_config_and_agents_skills() -> None:
     assert ".codex/rules/runops.rules" in bundle.files
     assert ".agents/skills/new-case/SKILL.md" in bundle.files
     assert ".agents/skills/setup-runops/SKILL.md" in bundle.files
+    assert ".agents/skills/setup-plugins/SKILL.md" in bundle.files
     assert ".agents/skills/research-agenda/SKILL.md" in bundle.files
     assert ".agents/skills/summarize-script/SKILL.md" in bundle.files
     assert ".agents/skills/patch-runops/SKILL.md" in bundle.files
@@ -128,6 +129,7 @@ def test_bundle_emits_codex_config_and_agents_skills() -> None:
     assert "$migrate-runops" in agents
     assert "$python-package-refactor" in agents
     assert "$setup-runops" in agents
+    assert "$setup-plugins" in agents
     assert "active question、current decision、paused/killed" in agents
     # Skills share the same frontmatter, but use each agent's native
     # invocation syntax in the body.
@@ -165,19 +167,27 @@ def test_bundle_emits_codex_config_and_agents_skills() -> None:
     assert "hops add-failure" in codex_feedback
     assert "hops feedback export --target runops --sanitize" in codex_feedback
     codex_setup = bundle.files[".agents/skills/setup-runops/SKILL.md"]
+    codex_setup_plugins = bundle.files[".agents/skills/setup-plugins/SKILL.md"]
     claude_setup = bundle.files[".claude/skills/setup-runops/SKILL.md"]
     assert "`$setup-env`" in codex_setup
     assert "`$setup-campaign`" in codex_setup
+    assert "`$setup-plugins`" in codex_setup
     assert "project は生成済み" in codex_setup
     assert "状態確認だけで応答を終えない" in codex_setup
     assert "必ず「セットアップ後に行うこと」" in codex_setup
     assert "project の状態はこちらで確認します" in codex_setup
     assert "doctor で未解決の項目はありますか" not in codex_setup
     assert 'git commit -m "chore: scaffold runops project"' in codex_setup
+    assert "runo plugins --json" in codex_setup_plugins
+    assert "Codex hooks は experimental" in codex_setup_plugins
+    assert "plugin-provided hook" in codex_setup_plugins
+    assert "runops project 側で hook を自作しない" in codex_setup_plugins
+    assert "`$setup-runops`" in codex_setup_plugins
     assert "`/setup-env`" in claude_setup
     assert "状態確認だけで応答を終えない" in claude_setup
     assert 'git commit -m "chore: scaffold runops project"' in claude_setup
     assert "{{ skill_prefix }}" not in codex_setup
+    assert "{{ skill_prefix }}" not in codex_setup_plugins
 
 
 def test_bundle_uses_simulator_adapter_alias_for_plugin_recommendations() -> None:


### PR DESCRIPTION
## Summary
- Add a project-distributed `setup-plugins` skill for recommended Codex plugin setup.
- Route `setup-runops` and user-facing docs to `$setup-plugins` / `/setup-plugins` before campaign setup when plugin activation is needed.
- Clarify that hook handling is limited to plugin-provided hook manifests/installers/activation hints, not runops-generated hooks.

## Validation
- `git diff --check`
- `tssrun -p eb uv run ruff check tests/test_harness/test_codex.py tests/test_cli/test_init.py tests/test_cli/test_update_harness.py`
- `tssrun -p eb uv run pytest tests/test_harness/test_codex.py tests/test_cli/test_init.py tests/test_cli/test_update_harness.py -q` (100 passed)
- `tssrun -p eb uv run pytest tests/test_harness -q` (19 passed)
