### PR TITLE
chore: release 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runops"
-version = "0.11.0"
+version = "0.12.0"
 description = "HPC simulation run management CLI tool for Slurm-based environments"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/runops/__init__.py
+++ b/src/runops/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,7 @@ wheels = [
 
 [[package]]
 name = "runops"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# runops 0.12.0

## 概要

このリリースでは、simulator や実行環境に固有の長文知識・cookbook・診断 workflow を runops 本体ではなく Codex plugin に委譲する運用を明確化しました。`runo plugins` と MCP の advisory contract を整備し、project harness から推奨 plugin を確認・導入しやすくしています。

## 主な追加機能

- `runo plugins` / `runops.project.plugins` で、project / simulator / site 由来の推奨 Codex plugin と `delegated_capabilities` を確認できるようにしました。
- EMSES、emout、BEACH、KUDPC などの外部 Codex plugin 推薦を project harness に表示し、install / activation hint を案内できるようにしました。
- 生成 project に `setup-plugins` skill を追加し、推奨 plugin の install / enable、plugin-provided hook の有効化手順を Agent が整理できるようにしました。
- simulator cookbook は plugin / explicit knowledge source を一次導線とし、`refs/` は opt-in の fallback mirror として扱う方針を docs と harness に反映しました。

## 主な修正・改善

- bundled adapter 登録と external plugin 推薦を分離し、runops 本体に simulator 固有の長文 workflow を抱え込まない構成に寄せました。
- HarnessOps lab overlay を repo 外へ移し、project checkout の管理対象を整理しました。
- `update-harness`、MCP metadata、knowledge layer、agent guide などのドキュメントを現行の plugin-first 仕様に合わせました。

## 補足

- `refs/` mirror は引き続き offline / private repo / 開発中 checkout 用の fallback として利用できます。
- runops は user-local な Codex plugin を自動 install / enable しません。生成 harness と `setup-plugins` skill は、project metadata に基づいて導入作業を支援します。
- Codex hooks は experimental であり、runops が hook を自作・既定生成するのではなく、plugin が明示的に提供する hook manifest / installer / activation hint がある場合だけ扱います。

## 検証

- `tssrun -p eb uv run ruff format --check src/ tests/`
- `tssrun -p eb uv run ruff check src/ tests/`
- `tssrun -p eb uv run mypy src/`
- `tssrun -p eb uv run pytest tests/ -x -q` (1191 passed)
- `tssrun -p eb uv run pytest --cov=runops --cov-branch --cov-report=term-missing --cov-fail-under=80` (1191 passed, coverage 80.91%)
