### PR TITLE
fix: add Codex agent role names

### DIFF
--- a/.codex/agents/beach.toml
+++ b/.codex/agents/beach.toml
@@ -1,3 +1,4 @@
+name = "beach"
 description = """
 BEACH を runops から扱うための薄い橋渡しエージェント。BEACH 固有の config review、case design、diagnosis、output analysis、visualization は BEACH Context plugin に委譲し、runops 側の run directory、adapter、manifest、job/harness 整合性を担当する。
 

--- a/.codex/agents/emses.toml
+++ b/.codex/agents/emses.toml
@@ -1,3 +1,4 @@
+name = "emses"
 description = """
 MPIEMSES3D を runops から扱うための薄い橋渡しエージェント。入力 review、parameter design、run diagnosis、HDF5/emout output analysis、visualization は MPIEMSES3D Context / emout Context plugin に委譲し、runops 側の run directory、adapter、launcher、manifest、job/harness 整合性を担当する。
 


### PR DESCRIPTION
## Summary
- add missing `name` fields to `.codex/agents/beach.toml` and `.codex/agents/emses.toml`
- fix malformed Codex agent role warnings during startup

## Verification
- `uv run python` TOML parse check for `.codex/agents/*.toml`
- `tssrun -p gr20001g -t 0:45:0 --rsc p=1:t=4:c=4 bash -lc 'cd /LARGE1/gr20001/b36291/Github/runops && uv run pytest tests/ -x -q && uv run ruff check src/ tests/ && uv run mypy src/'`\n- `tssrun -p gr20001g -t 0:10:0 --rsc p=1:t=2:c=2 bash -lc 'cd /LARGE1/gr20001/b36291/Github/runops && uv run ruff format --check src/ tests/'`